### PR TITLE
Add Level Properties + Container Traits

### DIFF
--- a/include/xsparse/level_capabilities/coordinate_iterate.hpp
+++ b/include/xsparse/level_capabilities/coordinate_iterate.hpp
@@ -169,7 +169,7 @@ namespace xsparse::level_capabilities
         private:
             typename BaseTraits::Level const& m_level;
             typename BaseTraits::I const m_i;
-            typename BaseTraits::IK m_pk_begin, m_pk_end;
+            typename BaseTraits::PK m_pk_begin, m_pk_end;
 
         public:
             class iterator;

--- a/include/xsparse/levels/compressed.hpp
+++ b/include/xsparse/levels/compressed.hpp
@@ -32,8 +32,8 @@ namespace xsparse
         {
             using BaseTraits = util::
                 base_traits<compressed, std::tuple<LowerLevels...>, IK, PK, ContainerTraits>;
-            using PosContainer = ContainerTraits::template Vec<PK>;
-            using CrdContainer = ContainerTraits::template Vec<IK>;
+            using PosContainer = typename ContainerTraits::template Vec<PK>;
+            using CrdContainer = typename ContainerTraits::template Vec<IK>;
 
         public:
             compressed(IK size)

--- a/include/xsparse/levels/compressed.hpp
+++ b/include/xsparse/levels/compressed.hpp
@@ -4,32 +4,36 @@
 #include <tuple>
 #include <utility>
 #include <vector>
+#include <unordered_map>
+#include <unordered_set>
 
 #include <xsparse/level_capabilities/coordinate_iterate.hpp>
+#include <xsparse/util/container_traits.hpp>
 
 namespace xsparse
 {
     namespace levels
     {
-        template <class LowerLevels, class IK, class PK, class PosContainer, class CrdContainer>
+        template <class LowerLevels,
+                  class IK,
+                  class PK,
+                  class ContainerTraits
+                  = util::container_traits<std::vector, std::unordered_set, std::unordered_map>>
         class compressed;
 
-        template <class... LowerLevels, class IK, class PK, class PosContainer, class CrdContainer>
-        class compressed<std::tuple<LowerLevels...>, IK, PK, PosContainer, CrdContainer>
+        template <class... LowerLevels, class IK, class PK, class ContainerTraits>
+        class compressed<std::tuple<LowerLevels...>, IK, PK, ContainerTraits>
             : public level_capabilities::coordinate_position_iterate<compressed,
                                                                      std::tuple<LowerLevels...>,
                                                                      IK,
                                                                      PK,
-                                                                     PosContainer,
-                                                                     CrdContainer>
+                                                                     ContainerTraits>
 
         {
-            using BaseTraits = util::base_traits<compressed,
-                                                 std::tuple<LowerLevels...>,
-                                                 IK,
-                                                 PK,
-                                                 PosContainer,
-                                                 CrdContainer>;
+            using BaseTraits = util::
+                base_traits<compressed, std::tuple<LowerLevels...>, IK, PK, ContainerTraits>;
+            using PosContainer = ContainerTraits::template Vec<PK>;
+            using CrdContainer = ContainerTraits::template Vec<IK>;
 
         public:
             compressed(IK size)
@@ -97,9 +101,9 @@ namespace xsparse
         };
     }  // namespace levels
 
-    template <class... LowerLevels, class IK, class PK, class PosContainer, class CrdContainer>
+    template <class... LowerLevels, class IK, class PK, class ContainerTraits>
     struct util::coordinate_position_trait<
-        levels::compressed<std::tuple<LowerLevels...>, IK, PK, PosContainer, CrdContainer>>
+        levels::compressed<std::tuple<LowerLevels...>, IK, PK, ContainerTraits>>
     {
         using Coordinate = IK;
         using Position = PK;

--- a/include/xsparse/levels/hashed.hpp
+++ b/include/xsparse/levels/hashed.hpp
@@ -9,6 +9,7 @@
 #include <unordered_map>
 
 #include <xsparse/util/base_traits.hpp>
+#include <xsparse/util/container_traits.hpp>
 #include <xtl/xiterator_base.hpp>
 
 namespace xsparse
@@ -28,7 +29,7 @@ namespace xsparse
             using BaseTraits
                 = util::base_traits<hashed, std::tuple<LowerLevels...>, IK, PK, ContainerTraits>;
             using CrdContainer
-                = ContainerTraits::template Vec<ContainerTraits::template Map<IK, PK>>;
+                = typename ContainerTraits::template Vec<typename ContainerTraits::template Map<IK, PK>>;
 
         public:
             class iteration_helper
@@ -40,7 +41,8 @@ namespace xsparse
                                                             typename BaseTraits::IK>);
 
             private:
-                ContainerTraits::template Map<BaseTraits::IK, BaseTraits::PK>& m_map;
+                using MapType = typename ContainerTraits::template Map<BaseTraits::IK, BaseTraits::PK>;
+                MapType& m_map;
 
             public:
                 class iterator;
@@ -56,7 +58,7 @@ namespace xsparse
                 {
                 private:
                     using wrapped_iterator_type
-                        = ContainerTraits::template Map<BaseTraits::IK,
+                        = typename ContainerTraits::template Map<BaseTraits::IK,
                                                         BaseTraits::PK>::const_iterator;
                     wrapped_iterator_type wrapped_it;
 

--- a/include/xsparse/levels/hashed.hpp
+++ b/include/xsparse/levels/hashed.hpp
@@ -28,8 +28,8 @@ namespace xsparse
         {
             using BaseTraits
                 = util::base_traits<hashed, std::tuple<LowerLevels...>, IK, PK, ContainerTraits>;
-            using CrdContainer
-                = typename ContainerTraits::template Vec<typename ContainerTraits::template Map<IK, PK>>;
+            using CrdContainer = typename ContainerTraits::template Vec<
+                typename ContainerTraits::template Map<IK, PK>>;
 
         public:
             class iteration_helper
@@ -41,8 +41,9 @@ namespace xsparse
                                                             typename BaseTraits::IK>);
 
             private:
-                using MapType = typename ContainerTraits::template Map<typename BaseTraits::IK, typename BaseTraits::PK>;
-                MapType& m_map;
+                typename ContainerTraits::template Map<typename BaseTraits::IK,
+                                                       typename BaseTraits::PK>
+                    m_map;
 
             public:
                 class iterator;
@@ -57,9 +58,9 @@ namespace xsparse
                 class iterator : public xtl::xbidirectional_iterator_base2<iteration_helper>
                 {
                 private:
-                    using wrapped_iterator_type
-                        = typename ContainerTraits::template Map<typename BaseTraits::IK,
-                                                        typename BaseTraits::PK>::const_iterator;
+                    using wrapped_iterator_type = typename ContainerTraits::template Map<
+                        typename BaseTraits::IK,
+                        typename BaseTraits::PK>::const_iterator;
                     wrapped_iterator_type wrapped_it;
 
                 public:
@@ -93,7 +94,8 @@ namespace xsparse
                 };
 
                 explicit inline iteration_helper(
-                    ContainerTraits::template Map<BaseTraits::IK, BaseTraits::PK>& map) noexcept
+                    typename ContainerTraits::template Map<typename BaseTraits::IK,
+                                                           typename BaseTraits::PK>& map) noexcept
                     : m_map(map)
                 {
                 }

--- a/include/xsparse/levels/hashed.hpp
+++ b/include/xsparse/levels/hashed.hpp
@@ -41,7 +41,7 @@ namespace xsparse
                                                             typename BaseTraits::IK>);
 
             private:
-                using MapType = typename ContainerTraits::template Map<BaseTraits::IK, BaseTraits::PK>;
+                using MapType = typename ContainerTraits::template Map<typename BaseTraits::IK, typename BaseTraits::PK>;
                 MapType& m_map;
 
             public:
@@ -58,8 +58,8 @@ namespace xsparse
                 {
                 private:
                     using wrapped_iterator_type
-                        = typename ContainerTraits::template Map<BaseTraits::IK,
-                                                        BaseTraits::PK>::const_iterator;
+                        = typename ContainerTraits::template Map<typename BaseTraits::IK,
+                                                        typename BaseTraits::PK>::const_iterator;
                     wrapped_iterator_type wrapped_it;
 
                 public:

--- a/include/xsparse/levels/offset.hpp
+++ b/include/xsparse/levels/offset.hpp
@@ -6,24 +6,31 @@
 #include <xsparse/util/base_traits.hpp>
 #include <xsparse/level_capabilities/coordinate_iterate.hpp>
 
+#include <xsparse/util/container_traits.hpp>
+
 namespace xsparse
 {
     namespace levels
     {
-        template <class LowerLevels, class IK, class PK, class OffsetContainer>
+        template <class LowerLevels,
+                  class IK,
+                  class PK,
+                  class ContainerTraits
+                  = util::container_traits<std::vector, std::unordered_set, std::unordered_map>>
         class offset;
 
-        template <class... LowerLevels, class IK, class PK, class OffsetContainer>
-        class offset<std::tuple<LowerLevels...>, IK, PK, OffsetContainer>
+        template <class... LowerLevels, class IK, class PK, class ContainerTraits>
+        class offset<std::tuple<LowerLevels...>, IK, PK, ContainerTraits>
             : public level_capabilities::coordinate_position_iterate<offset,
                                                                      std::tuple<LowerLevels...>,
                                                                      IK,
                                                                      PK,
-                                                                     OffsetContainer>
+                                                                     ContainerTraits>
 
         {
             using BaseTraits
-                = util::base_traits<offset, std::tuple<LowerLevels...>, IK, PK, OffsetContainer>;
+                = util::base_traits<offset, std::tuple<LowerLevels...>, IK, PK, ContainerTraits>;
+            using OffsetContainer = ContainerTraits::template Vec<PK>;
 
         public:
             offset(IK size)
@@ -62,9 +69,9 @@ namespace xsparse
         };
     }  // namespace levels
 
-    template <class... LowerLevels, class IK, class PK, class OffsetContainer>
+    template <class... LowerLevels, class IK, class PK, class ContainerTraits>
     struct util::coordinate_position_trait<
-        levels::offset<std::tuple<LowerLevels...>, IK, PK, OffsetContainer>>
+        levels::offset<std::tuple<LowerLevels...>, IK, PK, ContainerTraits>>
     {
         using Coordinate = IK;
         using Position = PK;

--- a/include/xsparse/levels/offset.hpp
+++ b/include/xsparse/levels/offset.hpp
@@ -30,7 +30,7 @@ namespace xsparse
         {
             using BaseTraits
                 = util::base_traits<offset, std::tuple<LowerLevels...>, IK, PK, ContainerTraits>;
-            using OffsetContainer = ContainerTraits::template Vec<PK>;
+            using OffsetContainer = typename ContainerTraits::template Vec<PK>;
 
         public:
             offset(IK size)

--- a/include/xsparse/levels/range.hpp
+++ b/include/xsparse/levels/range.hpp
@@ -29,7 +29,7 @@ namespace xsparse
         {
             using BaseTraits
                 = util::base_traits<range, std::tuple<LowerLevels...>, IK, PK, ContainerTraits>;
-            using OffsetContainer = ContainerTraits::template Vec<PK>;
+            using OffsetContainer = typename ContainerTraits::template Vec<PK>;
 
         public:
             range(IK size_N, IK size_M)

--- a/include/xsparse/levels/range.hpp
+++ b/include/xsparse/levels/range.hpp
@@ -6,23 +6,30 @@
 #include <xsparse/level_capabilities/coordinate_iterate.hpp>
 #include <tuple>
 
+#include <xsparse/util/container_traits.hpp>
+
 namespace xsparse
 {
     namespace levels
     {
-        template <class LowerLevels, class IK, class PK, class OffsetContainer>
+        template <class LowerLevels,
+                  class IK,
+                  class PK,
+                  class ContainerTraits
+                  = util::container_traits<std::vector, std::unordered_set, std::unordered_map>>
         class range;
 
-        template <class... LowerLevels, class IK, class PK, class OffsetContainer>
-        class range<std::tuple<LowerLevels...>, IK, PK, OffsetContainer>
+        template <class... LowerLevels, class IK, class PK, class ContainerTraits>
+        class range<std::tuple<LowerLevels...>, IK, PK, ContainerTraits>
             : public level_capabilities::coordinate_value_iterate<range,
                                                                   std::tuple<LowerLevels...>,
                                                                   IK,
                                                                   PK,
-                                                                  OffsetContainer>
+                                                                  ContainerTraits>
         {
             using BaseTraits
-                = util::base_traits<range, std::tuple<LowerLevels...>, IK, PK, OffsetContainer>;
+                = util::base_traits<range, std::tuple<LowerLevels...>, IK, PK, ContainerTraits>;
+            using OffsetContainer = ContainerTraits::template Vec<PK>;
 
         public:
             range(IK size_N, IK size_M)
@@ -67,9 +74,9 @@ namespace xsparse
         };
     }
 
-    template <class... LowerLevels, class IK, class PK, class OffsetContainer>
+    template <class... LowerLevels, class IK, class PK, class ContainerTraits>
     struct util::coordinate_position_trait<
-        levels::range<std::tuple<LowerLevels...>, IK, PK, OffsetContainer>>
+        levels::range<std::tuple<LowerLevels...>, IK, PK, ContainerTraits>>
     {
         using Coordinate = IK;
         using Position = PK;

--- a/include/xsparse/levels/singleton.hpp
+++ b/include/xsparse/levels/singleton.hpp
@@ -3,6 +3,9 @@
 
 #include <tuple>
 #include <utility>
+#include <vector>
+#include <unordered_set>
+#include <unordered_map>
 
 #include <xsparse/level_capabilities/coordinate_iterate.hpp>
 
@@ -10,20 +13,25 @@ namespace xsparse
 {
     namespace levels
     {
-        template <class LowerLevels, class IK, class PK, class CrdContainer>
+        template <class LowerLevels,
+                  class IK,
+                  class PK,
+                  class ContainerTraits
+                  = util::container_traits<std::vector, std::unordered_set, std::unordered_map>>
         class singleton;
 
-        template <class... LowerLevels, class IK, class PK, class CrdContainer>
-        class singleton<std::tuple<LowerLevels...>, IK, PK, CrdContainer>
+        template <class... LowerLevels, class IK, class PK, class ContainerTraits>
+        class singleton<std::tuple<LowerLevels...>, IK, PK, ContainerTraits>
             : public level_capabilities::coordinate_position_iterate<singleton,
                                                                      std::tuple<LowerLevels...>,
                                                                      IK,
                                                                      PK,
-                                                                     CrdContainer>
+                                                                     ContainerTraits>
 
         {
             using BaseTraits
-                = util::base_traits<singleton, std::tuple<LowerLevels...>, IK, PK, CrdContainer>;
+                = util::base_traits<singleton, std::tuple<LowerLevels...>, IK, PK, ContainerTraits>;
+            using CrdContainer = ContainerTraits::template Vec<PK>;
 
         public:
             singleton(IK size)
@@ -65,9 +73,9 @@ namespace xsparse
         };
     }  // namespace levels
 
-    template <class... LowerLevels, class IK, class PK, class CrdContainer>
+    template <class... LowerLevels, class IK, class PK, class ContainerTraits>
     struct util::coordinate_position_trait<
-        levels::singleton<std::tuple<LowerLevels...>, IK, PK, CrdContainer>>
+        levels::singleton<std::tuple<LowerLevels...>, IK, PK, ContainerTraits>>
     {
         using Coordinate = IK;
         using Position = PK;

--- a/include/xsparse/levels/singleton.hpp
+++ b/include/xsparse/levels/singleton.hpp
@@ -7,6 +7,7 @@
 #include <unordered_set>
 #include <unordered_map>
 
+#include <xsparse/util/container_traits.hpp>
 #include <xsparse/level_capabilities/coordinate_iterate.hpp>
 
 namespace xsparse
@@ -31,7 +32,7 @@ namespace xsparse
         {
             using BaseTraits
                 = util::base_traits<singleton, std::tuple<LowerLevels...>, IK, PK, ContainerTraits>;
-            using CrdContainer = ContainerTraits::template Vec<PK>;
+            using CrdContainer = typename ContainerTraits::template Vec<PK>;
 
         public:
             singleton(IK size)

--- a/include/xsparse/util/container_traits.hpp
+++ b/include/xsparse/util/container_traits.hpp
@@ -7,10 +7,18 @@
 
 namespace xsparse::util
 {
-    template <template <class...> class T, class LowerLevels, class IK, class PK, class... Containers>
+    template <template <class...> class T,
+              class LowerLevels,
+              class IK,
+              class PK,
+              class... Containers>
     struct container_traits;
 
-    template <template <class...> class T, class... LowerLevels, class IK, class PK, class... Containers>
+    template <template <class...> class T,
+              class... LowerLevels,
+              class IK,
+              class PK,
+              class... Containers>
     struct container_traits<T, std::tuple<LowerLevels...>, IK, PK, Containers...>
     {
         using Vector_pos_t = typename std::vector<PK>;

--- a/include/xsparse/util/container_traits.hpp
+++ b/include/xsparse/util/container_traits.hpp
@@ -7,17 +7,16 @@
 
 namespace xsparse::util
 {
-    template <class TVec, class TSet, class TMap>
-    struct container_traits;
-
-    template <class TVec = typename std::vector,
-              class TSet = typename std::unordered_set,
-              class TMap = typename std::unordered_map>
-    struct container_traits<TVec, TSet, TMap>
+    template <class IK,
+              class PK,
+              template <typename> class TVec,
+              template <typename> class TSet,
+              template <typename, typename> class TMap>
+    struct container_traits
     {
-        using Vec = TVec;
-        using Set = TSet;
-        using Map = TMap;
+        using Vec = TVec<IK>;
+        using Set = TSet<IK>;
+        using Map = TMap<IK, PK>;
     };
 }
 

--- a/include/xsparse/util/container_traits.hpp
+++ b/include/xsparse/util/container_traits.hpp
@@ -7,16 +7,21 @@
 
 namespace xsparse::util
 {
-    template <class IK,
-              class PK,
-              template <typename> class TVec,
-              template <typename> class TSet,
-              template <typename, typename> class TMap>
+    template <template <class> class TVec,
+              template <class>
+              class TSet,
+              template <class, class>
+              class TMap>
     struct container_traits
     {
-        using Vec = TVec<IK>;
-        using Set = TSet<IK>;
-        using Map = TMap<IK, PK>;
+        template <class Elem>
+        using Vec = TVec<Elem>;
+
+        template <class Elem>
+        using Set = TSet<Elem>;
+
+        template <class Key, class Val>
+        using Map = TMap<Key, Val>;
     };
 }
 

--- a/include/xsparse/util/container_traits.hpp
+++ b/include/xsparse/util/container_traits.hpp
@@ -1,0 +1,24 @@
+#ifndef XSPARSE_UTIL_CONTAINER_TRAITS_HPP
+#define XSPARSE_UTIL_CONTAINER_TRAITS_HPP
+#include <tuple>
+#include <vector>
+#include <set>
+#include <unordered_map>
+
+namespace xsparse::util
+{
+    template <template <class...> class T, class LowerLevels, class IK, class PK, class... Containers>
+    struct container_traits;
+
+    template <template <class...> class T, class... LowerLevels, class IK, class PK, class... Containers>
+    struct container_traits<T, std::tuple<LowerLevels...>, IK, PK, Containers...>
+    {
+        using Vector_pos_t = typename std::vector<PK>;
+        using Vector_crd_t = typename std::vector<IK>;
+        using Set_pos_t = typename std::set<PK>;
+        using Set_crd_t = typename std::set<IK>;
+        using Unordered_map_t = typename std::unordered_map<IK, PK>;
+    };
+}
+
+#endif

--- a/include/xsparse/util/container_traits.hpp
+++ b/include/xsparse/util/container_traits.hpp
@@ -7,23 +7,17 @@
 
 namespace xsparse::util
 {
-    template <template <class...> class T,
-              class LowerLevels,
-              class IK,
-              class PK,
-              class... Containers>
+    template <class TVec, class TSet, class TMap>
     struct container_traits;
 
-    template <template <class...> class T,
-              class... LowerLevels,
-              class IK,
-              class PK,
-              class... Containers>
-    struct container_traits<T, std::tuple<LowerLevels...>, IK, PK, Containers...>
+    template <class TVec = typename std::vector,
+              class TSet = typename std::unordered_set,
+              class TMap = typename std::unordered_map>
+    struct container_traits<TVec, TSet, TMap>
     {
-        using Vector_t = typename std::vector;
-        using Unordered_set_t = typename std::unordered_set;
-        using Unordered_map_t = typename std::unordered_map;
+        using Vec = TVec;
+        using Set = TSet;
+        using Map = TMap;
     };
 }
 

--- a/include/xsparse/util/container_traits.hpp
+++ b/include/xsparse/util/container_traits.hpp
@@ -7,10 +7,10 @@
 
 namespace xsparse::util
 {
-    template <template <class> class TVec,
-              template <class>
+    template <template <class...> class TVec,
+              template <class...>
               class TSet,
-              template <class, class>
+              template <class...>
               class TMap>
     struct container_traits
     {

--- a/include/xsparse/util/container_traits.hpp
+++ b/include/xsparse/util/container_traits.hpp
@@ -2,7 +2,7 @@
 #define XSPARSE_UTIL_CONTAINER_TRAITS_HPP
 #include <tuple>
 #include <vector>
-#include <set>
+#include <unordered_set>
 #include <unordered_map>
 
 namespace xsparse::util
@@ -21,11 +21,9 @@ namespace xsparse::util
               class... Containers>
     struct container_traits<T, std::tuple<LowerLevels...>, IK, PK, Containers...>
     {
-        using Vector_pos_t = typename std::vector<PK>;
-        using Vector_crd_t = typename std::vector<IK>;
-        using Set_pos_t = typename std::set<PK>;
-        using Set_crd_t = typename std::set<IK>;
-        using Unordered_map_t = typename std::unordered_map<IK, PK>;
+        using Vector_t = typename std::vector;
+        using Unordered_set_t = typename std::unordered_set;
+        using Unordered_map_t = typename std::unordered_map;
     };
 }
 

--- a/test/source/compressed_test.cpp
+++ b/test/source/compressed_test.cpp
@@ -2,10 +2,15 @@
 
 #include <tuple>
 #include <vector>
+#include <list>
+#include <map>
+#include <set>
 
 #include <xsparse/levels/compressed.hpp>
 #include <xsparse/levels/dense.hpp>
 #include <xsparse/version.h>
+
+#include <xsparse/util/container_traits.hpp>
 
 TEST_CASE("Compressed-BaseCase")
 {
@@ -15,12 +20,7 @@ TEST_CASE("Compressed-BaseCase")
     std::vector<uintptr_t> const pos{ 0, 5 };
     std::vector<uintptr_t> const crd{ 20, 30, 50, 60, 70 };
 
-    xsparse::levels::compressed<std::tuple<>,
-                                uintptr_t,
-                                uintptr_t,
-                                std::vector<uintptr_t>,
-                                std::vector<uintptr_t>>
-        s{ SIZE, pos, crd };
+    xsparse::levels::compressed<std::tuple<>, uintptr_t, uintptr_t> s{ SIZE, pos, crd };
 
     uintptr_t l = 0;
     for (auto const [i, p] : s.iter_helper(std::make_tuple(), ZERO))
@@ -45,8 +45,7 @@ TEST_CASE("Compressed-CSR")
     xsparse::levels::compressed<std::tuple<decltype(d1)>,
                                 uintptr_t,
                                 uintptr_t,
-                                std::vector<uintptr_t>,
-                                std::vector<uintptr_t>>
+                                xsparse::util::container_traits<std::vector, std::set, std::map>>
         s2{ SIZE2, pos, crd };
 
 
@@ -79,17 +78,12 @@ TEST_CASE("Compressed-DCSR")
     std::vector<uintptr_t> const pos2{ 0, 2, 5, 9 };
     std::vector<uintptr_t> const crd2{ 20, 50, 30, 40, 70, 10, 60, 80, 90 };
 
-    xsparse::levels::compressed<std::tuple<>,
-                                uintptr_t,
-                                uintptr_t,
-                                std::vector<uintptr_t>,
-                                std::vector<uintptr_t>>
-        s1{ SIZE1, pos1, crd1 };
-    xsparse::levels::compressed<std::tuple<decltype(s1)>,
-                                uintptr_t,
-                                uintptr_t,
-                                std::vector<uintptr_t>,
-                                std::vector<uintptr_t>>
+    xsparse::levels::compressed<std::tuple<>, uintptr_t, uintptr_t> s1{ SIZE1, pos1, crd1 };
+    xsparse::levels::compressed<
+        std::tuple<decltype(s1)>,
+        uintptr_t,
+        uintptr_t,
+        xsparse::util::container_traits<std::vector, std::unordered_set, std::map>>
         s2{ SIZE2, pos2, crd2 };
 
 
@@ -124,12 +118,9 @@ TEST_CASE("Compressed-CSR-Append")
     std::vector<uintptr_t> crd;
 
     xsparse::levels::dense<std::tuple<>, uintptr_t, uintptr_t> d1{ SIZE1 };
-    xsparse::levels::compressed<std::tuple<decltype(d1)>,
-                                uintptr_t,
-                                uintptr_t,
-                                std::vector<uintptr_t>,
-                                std::vector<uintptr_t>>
-        s2{ SIZE2, pos, crd };
+    xsparse::levels::compressed<std::tuple<decltype(d1)>, uintptr_t, uintptr_t> s2{ SIZE2,
+                                                                                    pos,
+                                                                                    crd };
 
     s2.append_init(SIZE1);
 

--- a/test/source/hashed_test.cpp
+++ b/test/source/hashed_test.cpp
@@ -3,8 +3,11 @@
 #include <xsparse/levels/dense.hpp>
 #include <xsparse/levels/singleton.hpp>
 
+#include <xsparse/util/container_traits.hpp>
+
 #include <vector>
 #include <unordered_map>
+#include <set>
 
 TEST_CASE("Dense-Hashed")
 {
@@ -20,11 +23,7 @@ TEST_CASE("Dense-Hashed")
 
     xsparse::levels::dense<std::tuple<>, uintptr_t, uintptr_t> d{ SIZE0 };
 
-    xsparse::levels::hashed<std::tuple<decltype(d)>,
-                            uintptr_t,
-                            uintptr_t,
-                            std::vector<std::unordered_map<uintptr_t, uintptr_t>>>
-        h{ SIZE1, crd };
+    xsparse::levels::hashed<std::tuple<decltype(d)>, uintptr_t, uintptr_t> h{ SIZE1, crd };
 
     uintptr_t l1 = 0;
     for (auto const [i1, p1] : d.iter_helper(std::make_tuple(), ZERO))
@@ -59,16 +58,18 @@ TEST_CASE("Hashed-Hashed")
 
     std::vector<std::unordered_map<uintptr_t, uintptr_t>> const crd1{ umap2, umap3, umap4 };
 
-    xsparse::levels::hashed<std::tuple<>,
-                            uintptr_t,
-                            uintptr_t,
-                            std::vector<std::unordered_map<uintptr_t, uintptr_t>>>
+    xsparse::levels::hashed<
+        std::tuple<>,
+        uintptr_t,
+        uintptr_t,
+        xsparse::util::container_traits<std::vector, std::set, std::unordered_map>>
         h{ SIZE0, crd0 };
 
-    xsparse::levels::hashed<std::tuple<decltype(h)>,
-                            uintptr_t,
-                            uintptr_t,
-                            std::vector<std::unordered_map<uintptr_t, uintptr_t>>>
+    xsparse::levels::hashed<
+        std::tuple<decltype(h)>,
+        uintptr_t,
+        uintptr_t,
+        xsparse::util::container_traits<std::vector, std::set, std::unordered_map>>
         h1{ SIZE1, crd1 };
 
     uintptr_t l1 = 0;
@@ -99,15 +100,9 @@ TEST_CASE("Hashed-Singleton")
 
     std::vector<uintptr_t> const crd1{ 0, 3, 4 };
 
-    xsparse::levels::hashed<std::tuple<>,
-                            uintptr_t,
-                            uintptr_t,
-                            std::vector<std::unordered_map<uintptr_t, uintptr_t>>>
-        h{ SIZE0, crd0 };
+    xsparse::levels::hashed<std::tuple<>, uintptr_t, uintptr_t> h{ SIZE0, crd0 };
 
-    xsparse::levels::
-        singleton<std::tuple<decltype(h)>, uintptr_t, uintptr_t, std::vector<uintptr_t>>
-            s{ SIZE1, crd1 };
+    xsparse::levels::singleton<std::tuple<decltype(h)>, uintptr_t, uintptr_t> s{ SIZE1, crd1 };
 
     uintptr_t l1 = 0;
     for (auto const [i1, p1] : h.iter_helper(ZERO))
@@ -140,14 +135,13 @@ TEST_CASE("Hashed-Singleton-Dense")
     std::vector<std::unordered_map<uintptr_t, uintptr_t>> const crd0{ umap1 };
     std::vector<uintptr_t> const crd1 = { 0, 2, 0, 2, 3 };
 
-    xsparse::levels::hashed<std::tuple<>,
-                            uintptr_t,
-                            uintptr_t,
-                            std::vector<std::unordered_map<uintptr_t, uintptr_t>>>
+    xsparse::levels::hashed<
+        std::tuple<>,
+        uintptr_t,
+        uintptr_t,
+        xsparse::util::container_traits<std::vector, std::set, std::unordered_map>>
         h{ SIZE0, crd0 };
-    xsparse::levels::
-        singleton<std::tuple<decltype(h)>, uintptr_t, uintptr_t, std::vector<uintptr_t>>
-            s{ SIZE1, crd1 };
+    xsparse::levels::singleton<std::tuple<decltype(h)>, uintptr_t, uintptr_t> s{ SIZE1, crd1 };
     xsparse::levels::dense<std::tuple<decltype(s)>, uintptr_t, uintptr_t> d{ SIZE2 };
 
     uintptr_t l1 = 0;
@@ -199,11 +193,7 @@ TEST_CASE("Dense-Hashed-Insert")
 
     std::vector<std::unordered_map<uintptr_t, uintptr_t>> const crd;
 
-    xsparse::levels::hashed<std::tuple<decltype(d)>,
-                            uintptr_t,
-                            uintptr_t,
-                            std::vector<std::unordered_map<uintptr_t, uintptr_t>>>
-        h{ SIZE1, crd };
+    xsparse::levels::hashed<std::tuple<decltype(d)>, uintptr_t, uintptr_t> h{ SIZE1, crd };
 
     h.insert_init(SIZE0);
 

--- a/test/source/range_test.cpp
+++ b/test/source/range_test.cpp
@@ -21,12 +21,9 @@ TEST_CASE("Range-DIA")
 
     xsparse::levels::dense<std::tuple<>, uintptr_t, uintptr_t> d{ SIZE };
 
-    xsparse::levels::range<std::tuple<decltype(d)>, uintptr_t, uintptr_t, std::vector<int16_t>> r{
-        SIZE_N, SIZE_M, offset
-    };
-    xsparse::levels::
-        offset<std::tuple<decltype(r), decltype(d)>, uintptr_t, uintptr_t, std::vector<int16_t>>
-            o{ SIZE, offset };
+    xsparse::levels::range<std::tuple<decltype(d)>, uintptr_t, int16_t> r{ SIZE_N, SIZE_M, offset };
+    xsparse::levels::offset<std::tuple<decltype(r), decltype(d)>, uintptr_t, int16_t> o{ SIZE,
+                                                                                         offset };
 
     uintptr_t l1 = 0;
 

--- a/test/source/singleton_test.cpp
+++ b/test/source/singleton_test.cpp
@@ -2,9 +2,14 @@
 
 #include <iostream>
 #include <vector>
+#include <unordered_map>
+#include <set>
+#include <map>
 
 #include <xsparse/levels/compressed.hpp>
 #include <xsparse/levels/singleton.hpp>
+
+#include <xsparse/util/container_traits.hpp>
 
 TEST_CASE("Singleton-COO")
 {
@@ -16,16 +21,9 @@ TEST_CASE("Singleton-COO")
     std::vector<uintptr_t> const crd0{ 0, 0, 1, 1, 3, 3, 3 };
     std::vector<uintptr_t> const crd1{ 0, 1, 0, 1, 0, 3, 4 };
 
-    xsparse::levels::compressed<std::tuple<>,
-                                uintptr_t,
-                                uintptr_t,
-                                std::vector<uintptr_t>,
-                                std::vector<uintptr_t>>
-        c{ SIZE, pos, crd0 };
+    xsparse::levels::compressed<std::tuple<>, uintptr_t, uintptr_t> c{ SIZE, pos, crd0 };
 
-    xsparse::levels::
-        singleton<std::tuple<decltype(c)>, uintptr_t, uintptr_t, std::vector<uintptr_t>>
-            s{ SIZE1, crd1 };
+    xsparse::levels::singleton<std::tuple<decltype(c)>, uintptr_t, uintptr_t> s{ SIZE1, crd1 };
 
     uintptr_t l1 = 0;
     for (auto const [i1, p1] : c.iter_helper(std::make_tuple(), ZERO))
@@ -57,20 +55,24 @@ TEST_CASE("Singleton-COO-3D")
     std::vector<uintptr_t> const crd1{ 0, 0, 2, 0, 2, 2, 3, 3 };
     std::vector<uintptr_t> const crd2{ 0, 1, 1, 1, 0, 1, 0, 1 };
 
-    xsparse::levels::compressed<std::tuple<>,
-                                uintptr_t,
-                                uintptr_t,
-                                std::vector<uintptr_t>,
-                                std::vector<uintptr_t>>
+    xsparse::levels::compressed<
+        std::tuple<>,
+        uintptr_t,
+        uintptr_t,
+        xsparse::util::container_traits<std::vector, std::set, std::unordered_map>>
         c{ SIZE, pos, crd0 };
 
-    xsparse::levels::
-        singleton<std::tuple<decltype(c)>, uintptr_t, uintptr_t, std::vector<uintptr_t>>
-            s{ SIZE1, crd1 };
+    xsparse::levels::singleton<std::tuple<decltype(c)>,
+                               uintptr_t,
+                               uintptr_t,
+                               xsparse::util::container_traits<std::vector, std::set, std::map>>
+        s{ SIZE1, crd1 };
 
-    xsparse::levels::
-        singleton<std::tuple<decltype(s)>, uintptr_t, uintptr_t, std::vector<uintptr_t>>
-            s1{ SIZE2, crd2 };
+    xsparse::levels::singleton<std::tuple<decltype(s)>,
+                               uintptr_t,
+                               uintptr_t,
+                               xsparse::util::container_traits<std::vector, std::set, std::map>>
+        s1{ SIZE2, crd2 };
 
     uintptr_t l1 = 0;
     for (auto const [i1, p1] : c.iter_helper(std::make_tuple(), ZERO))
@@ -112,16 +114,9 @@ TEST_CASE("Singleton-COO-Append")
     std::vector<uintptr_t> const crd0;
     std::vector<uintptr_t> const crd1;
 
-    xsparse::levels::compressed<std::tuple<>,
-                                uintptr_t,
-                                uintptr_t,
-                                std::vector<uintptr_t>,
-                                std::vector<uintptr_t>>
-        c{ SIZE, pos, crd0 };
+    xsparse::levels::compressed<std::tuple<>, uintptr_t, uintptr_t> c{ SIZE, pos, crd0 };
 
-    xsparse::levels::
-        singleton<std::tuple<decltype(c)>, uintptr_t, uintptr_t, std::vector<uintptr_t>>
-            s{ SIZE1, crd1 };
+    xsparse::levels::singleton<std::tuple<decltype(c)>, uintptr_t, uintptr_t> s{ SIZE1, crd1 };
 
     c.append_init(SIZE);
 


### PR DESCRIPTION
I've added the `container_traits` for `vector`, `set` & `unordered_map`. If the template parameters look good, we can get the levels to inherit from these container traits.