### PR TITLE
[ENH] Add `LevelProperty` public attribute to all the levels

### DIFF
--- a/include/xsparse/level_capabilities/co_iteration.hpp
+++ b/include/xsparse/level_capabilities/co_iteration.hpp
@@ -30,6 +30,13 @@ namespace xsparse::level_capabilities
             }
         }
 
+        // Function to get the is_ordered properties of the levels as a tuple of booleans
+        constexpr auto ordered_levels() const noexcept {
+            return std::apply([](auto&... levels) {
+                return std::tuple{levels.is_ordered...};
+            }, m_levelsTuple);
+        }
+
     public:
         class coiteration_helper
         {

--- a/include/xsparse/level_capabilities/co_iteration.hpp
+++ b/include/xsparse/level_capabilities/co_iteration.hpp
@@ -31,10 +31,10 @@ namespace xsparse::level_capabilities
         }
 
         // Function to get the is_ordered properties of the levels as a tuple of booleans
-        constexpr auto ordered_levels() const noexcept {
-            return std::apply([](auto&... levels) {
-                return std::tuple{levels.is_ordered...};
-            }, m_levelsTuple);
+        constexpr auto ordered_levels() const noexcept
+        {
+            return std::apply([](auto&... levels) { return std::tuple{ levels.is_ordered... }; },
+                              m_levelsTuple);
         }
 
     public:

--- a/include/xsparse/level_capabilities/co_iteration.hpp
+++ b/include/xsparse/level_capabilities/co_iteration.hpp
@@ -30,13 +30,6 @@ namespace xsparse::level_capabilities
             }
         }
 
-        // Function to get the is_ordered properties of the levels as a tuple of booleans
-        constexpr auto ordered_levels() const noexcept
-        {
-            return std::apply([](auto&... levels) { return std::tuple{ levels.is_ordered... }; },
-                              m_levelsTuple);
-        }
-
     public:
         class coiteration_helper
         {

--- a/include/xsparse/levels/compressed.hpp
+++ b/include/xsparse/levels/compressed.hpp
@@ -56,8 +56,14 @@ namespace xsparse
                                                                   PK,
                                                                   ContainerTraits,
                                                                   LevelProperties>;
-            using LevelProperty = LevelProperties;  // Expose LevelProperties as a public attribute
+
         public:
+            // Function to access the LevelProperties object
+            constexpr LevelProperties LevelProperty() const
+            {
+                return LevelProperties{};
+            }
+
             compressed(IK size)
                 : m_size(std::move(size))
                 , m_pos()

--- a/include/xsparse/levels/compressed.hpp
+++ b/include/xsparse/levels/compressed.hpp
@@ -20,25 +20,25 @@ namespace xsparse
                   class PK,
                   class ContainerTraits
                   = util::container_traits<std::vector, std::unordered_set, std::unordered_map>,
-                  class LevelProperties = level_properties<true, true, true, false, true>>
+                  class _LevelProperties = level_properties<true, true, true, false, true>>
         class compressed;
 
         template <class... LowerLevels,
                   class IK,
                   class PK,
                   class ContainerTraits,
-                  class LevelProperties>
-        class compressed<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, LevelProperties>
+                  class _LevelProperties>
+        class compressed<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, _LevelProperties>
             : public level_capabilities::coordinate_position_iterate<compressed,
                                                                      std::tuple<LowerLevels...>,
                                                                      IK,
                                                                      PK,
                                                                      ContainerTraits,
-                                                                     LevelProperties>
+                                                                     _LevelProperties>
 
         {
-            static_assert(!LevelProperties::is_branchless);
-            static_assert(LevelProperties::is_compact);
+            static_assert(!_LevelProperties::is_branchless);
+            static_assert(_LevelProperties::is_compact);
             using PosContainer = typename ContainerTraits::template Vec<PK>;
             using CrdContainer = typename ContainerTraits::template Vec<IK>;
 
@@ -48,22 +48,17 @@ namespace xsparse
                                                  IK,
                                                  PK,
                                                  ContainerTraits,
-                                                 LevelProperties>;
+                                                 _LevelProperties>;
             using LevelCapabilities
                 = level_capabilities::coordinate_position_iterate<compressed,
                                                                   std::tuple<LowerLevels...>,
                                                                   IK,
                                                                   PK,
                                                                   ContainerTraits,
-                                                                  LevelProperties>;
+                                                                  _LevelProperties>;
+            using LevelProperties = _LevelProperties;
 
         public:
-            // Function to access the LevelProperties object
-            constexpr LevelProperties level_property() const
-            {
-                return LevelProperties{};
-            }
-
             compressed(IK size)
                 : m_size(std::move(size))
                 , m_pos()
@@ -138,9 +133,9 @@ namespace xsparse
               class IK,
               class PK,
               class ContainerTraits,
-              class LevelProperties>
+              class _LevelProperties>
     struct util::coordinate_position_trait<
-        levels::compressed<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, LevelProperties>>
+        levels::compressed<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, _LevelProperties>>
     {
         using Coordinate = IK;
         using Position = PK;

--- a/include/xsparse/levels/compressed.hpp
+++ b/include/xsparse/levels/compressed.hpp
@@ -56,7 +56,7 @@ namespace xsparse
                                                                   PK,
                                                                   ContainerTraits,
                                                                   LevelProperties>;
-
+            using LevelProperty = LevelProperties;  // Expose LevelProperties as a public attribute
         public:
             compressed(IK size)
                 : m_size(std::move(size))

--- a/include/xsparse/levels/compressed.hpp
+++ b/include/xsparse/levels/compressed.hpp
@@ -59,7 +59,7 @@ namespace xsparse
 
         public:
             // Function to access the LevelProperties object
-            constexpr LevelProperties LevelProperty() const
+            constexpr LevelProperties level_property() const
             {
                 return LevelProperties{};
             }

--- a/include/xsparse/levels/dense.hpp
+++ b/include/xsparse/levels/dense.hpp
@@ -38,10 +38,10 @@ namespace xsparse
                                                                LevelProperties>;
             using BaseTraits
                 = util::base_traits<dense, std::tuple<LowerLevels...>, IK, PK, LevelProperties>;
-            using LevelProperty = LevelProperties;  // Expose LevelProperties as a public attribute
+
         public:
             // Function to access the LevelProperties object
-            const LevelProperties LevelProperty() const
+            constexpr LevelProperties LevelProperty() const
             {
                 return LevelProperties{};
             }

--- a/include/xsparse/levels/dense.hpp
+++ b/include/xsparse/levels/dense.hpp
@@ -38,7 +38,7 @@ namespace xsparse
                                                                LevelProperties>;
             using BaseTraits
                 = util::base_traits<dense, std::tuple<LowerLevels...>, IK, PK, LevelProperties>;
-
+            using LevelProperty = LevelProperties;  // Expose LevelProperties as a public attribute
         public:
             dense(IK size)
                 : m_size(std::move(size))

--- a/include/xsparse/levels/dense.hpp
+++ b/include/xsparse/levels/dense.hpp
@@ -13,22 +13,22 @@ namespace xsparse
         template <class LowerLevels,
                   class IK,
                   class PK,
-                  class LevelProperties = level_properties<true, true, true, false, true>>
+                  class _LevelProperties = level_properties<true, true, true, false, true>>
         class dense;
 
-        template <class... LowerLevels, class IK, class PK, class LevelProperties>
-        class dense<std::tuple<LowerLevels...>, IK, PK, LevelProperties>
+        template <class... LowerLevels, class IK, class PK, class _LevelProperties>
+        class dense<std::tuple<LowerLevels...>, IK, PK, _LevelProperties>
             : public level_capabilities::coordinate_value_iterate<dense,
                                                                   std::tuple<LowerLevels...>,
                                                                   IK,
                                                                   PK,
-                                                                  LevelProperties>
+                                                                  _LevelProperties>
 
         {
-            static_assert(LevelProperties::is_full);
-            static_assert(!LevelProperties::is_branchless);
-            static_assert(LevelProperties::is_compact);
-            static_assert(LevelProperties::is_ordered);
+            static_assert(_LevelProperties::is_full);
+            static_assert(!_LevelProperties::is_branchless);
+            static_assert(_LevelProperties::is_compact);
+            static_assert(_LevelProperties::is_ordered);
 
         public:
             using LevelCapabilities
@@ -36,17 +36,12 @@ namespace xsparse
                                                                std::tuple<LowerLevels...>,
                                                                IK,
                                                                PK,
-                                                               LevelProperties>;
+                                                               _LevelProperties>;
             using BaseTraits
-                = util::base_traits<dense, std::tuple<LowerLevels...>, IK, PK, LevelProperties>;
+                = util::base_traits<dense, std::tuple<LowerLevels...>, IK, PK, _LevelProperties>;
+            using LevelProperties = _LevelProperties;
 
         public:
-            // Function to access the LevelProperties object
-            constexpr LevelProperties level_property() const
-            {
-                return LevelProperties{};
-            }
-
             dense(IK size)
                 : m_size(std::move(size))
             {
@@ -80,9 +75,9 @@ namespace xsparse
         };
     }
 
-    template <class... LowerLevels, class IK, class PK, class LevelProperties>
+    template <class... LowerLevels, class IK, class PK, class _LevelProperties>
     struct util::coordinate_position_trait<
-        levels::dense<std::tuple<LowerLevels...>, IK, PK, LevelProperties>>
+        levels::dense<std::tuple<LowerLevels...>, IK, PK, _LevelProperties>>
     {
         using Coordinate = IK;
         using Position = PK;

--- a/include/xsparse/levels/dense.hpp
+++ b/include/xsparse/levels/dense.hpp
@@ -42,7 +42,7 @@ namespace xsparse
 
         public:
             // Function to access the LevelProperties object
-            constexpr LevelProperties LevelProperty() const
+            constexpr LevelProperties level_property() const
             {
                 return LevelProperties{};
             }

--- a/include/xsparse/levels/dense.hpp
+++ b/include/xsparse/levels/dense.hpp
@@ -28,6 +28,7 @@ namespace xsparse
             static_assert(LevelProperties::is_full);
             static_assert(!LevelProperties::is_branchless);
             static_assert(LevelProperties::is_compact);
+            static_assert(LevelProperties::is_ordered);
 
         public:
             using LevelCapabilities

--- a/include/xsparse/levels/dense.hpp
+++ b/include/xsparse/levels/dense.hpp
@@ -40,6 +40,12 @@ namespace xsparse
                 = util::base_traits<dense, std::tuple<LowerLevels...>, IK, PK, LevelProperties>;
             using LevelProperty = LevelProperties;  // Expose LevelProperties as a public attribute
         public:
+            // Function to access the LevelProperties object
+            const LevelProperties LevelProperty() const
+            {
+                return LevelProperties{};
+            }
+
             dense(IK size)
                 : m_size(std::move(size))
             {

--- a/include/xsparse/levels/hashed.hpp
+++ b/include/xsparse/levels/hashed.hpp
@@ -132,7 +132,7 @@ namespace xsparse
             }
 
             // Function to access the LevelProperties object
-            constexpr LevelProperties LevelProperty() const
+            constexpr LevelProperties level_property() const
             {
                 return LevelProperties{};
             }

--- a/include/xsparse/levels/hashed.hpp
+++ b/include/xsparse/levels/hashed.hpp
@@ -45,7 +45,7 @@ namespace xsparse
                                                  PK,
                                                  ContainerTraits,
                                                  LevelProperties>;
-            using LevelProperty = LevelProperties;  // Expose LevelProperties as a public attribute
+
         public:
             class iteration_helper
             {
@@ -129,6 +129,12 @@ namespace xsparse
             iteration_helper iter_helper(typename BaseTraits::PKM1 pkm1)
             {
                 return iteration_helper{ this->m_crd[pkm1] };
+            }
+
+            // Function to access the LevelProperties object
+            constexpr LevelProperties LevelProperty() const
+            {
+                return LevelProperties{};
             }
 
             hashed(IK size)

--- a/include/xsparse/levels/hashed.hpp
+++ b/include/xsparse/levels/hashed.hpp
@@ -45,7 +45,7 @@ namespace xsparse
                                                  PK,
                                                  ContainerTraits,
                                                  LevelProperties>;
-
+            using LevelProperty = LevelProperties;  // Expose LevelProperties as a public attribute
         public:
             class iteration_helper
             {

--- a/include/xsparse/levels/hashed.hpp
+++ b/include/xsparse/levels/hashed.hpp
@@ -22,19 +22,19 @@ namespace xsparse
                   class PK,
                   class ContainerTraits
                   = util::container_traits<std::vector, std::unordered_set, std::unordered_map>,
-                  class LevelProperties = level_properties<true, false, true, false, false>>
+                  class _LevelProperties = level_properties<true, false, true, false, false>>
         class hashed;
 
         template <class... LowerLevels,
                   class IK,
                   class PK,
                   class ContainerTraits,
-                  class LevelProperties>
-        class hashed<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, LevelProperties>
+                  class _LevelProperties>
+        class hashed<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, _LevelProperties>
         {
-            static_assert(!LevelProperties::is_ordered);
-            static_assert(!LevelProperties::is_branchless);
-            static_assert(!LevelProperties::is_compact);
+            static_assert(!_LevelProperties::is_ordered);
+            static_assert(!_LevelProperties::is_branchless);
+            static_assert(!_LevelProperties::is_compact);
             using CrdContainer = typename ContainerTraits::template Vec<
                 typename ContainerTraits::template Map<IK, PK>>;
 
@@ -44,7 +44,8 @@ namespace xsparse
                                                  IK,
                                                  PK,
                                                  ContainerTraits,
-                                                 LevelProperties>;
+                                                 _LevelProperties>;
+            using LevelProperties = _LevelProperties;
 
         public:
             class iteration_helper
@@ -131,12 +132,6 @@ namespace xsparse
                 return iteration_helper{ this->m_crd[pkm1] };
             }
 
-            // Function to access the LevelProperties object
-            constexpr LevelProperties level_property() const
-            {
-                return LevelProperties{};
-            }
-
             hashed(IK size)
                 : m_size(std::move(size))
                 , m_crd()
@@ -186,9 +181,9 @@ namespace xsparse
               class IK,
               class PK,
               class ContainerTraits,
-              class LevelProperties>
+              class _LevelProperties>
     struct util::coordinate_position_trait<
-        levels::hashed<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, LevelProperties>>
+        levels::hashed<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, _LevelProperties>>
     {
         using Coordinate = IK;
         using Position = PK;

--- a/include/xsparse/levels/offset.hpp
+++ b/include/xsparse/levels/offset.hpp
@@ -54,7 +54,7 @@ namespace xsparse
                                                                   PK,
                                                                   ContainerTraits,
                                                                   LevelProperties>;
-            using LevelProperty = LevelProperties;  // Expose LevelProperties as a public attribute
+
         public:
             offset(IK size)
                 : m_size(std::move(size))
@@ -72,6 +72,12 @@ namespace xsparse
                 : m_size(std::move(size))
                 , m_offset(offset)
             {
+            }
+
+            // Function to access the LevelProperties object
+            constexpr LevelProperties LevelProperty() const
+            {
+                return LevelProperties{};
             }
 
             inline std::pair<PK, PK> pos_bounds(typename BaseTraits::PKM1 pkm1) const noexcept

--- a/include/xsparse/levels/offset.hpp
+++ b/include/xsparse/levels/offset.hpp
@@ -18,26 +18,26 @@ namespace xsparse
                   class PK,
                   class ContainerTraits
                   = util::container_traits<std::vector, std::unordered_set, std::unordered_map>,
-                  class LevelProperties = level_properties<false, true, true, true, false>>
+                  class _LevelProperties = level_properties<false, true, true, true, false>>
         class offset;
 
         template <class... LowerLevels,
                   class IK,
                   class PK,
                   class ContainerTraits,
-                  class LevelProperties>
-        class offset<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, LevelProperties>
+                  class _LevelProperties>
+        class offset<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, _LevelProperties>
             : public level_capabilities::coordinate_position_iterate<offset,
                                                                      std::tuple<LowerLevels...>,
                                                                      IK,
                                                                      PK,
                                                                      ContainerTraits,
-                                                                     LevelProperties>
+                                                                     _LevelProperties>
 
         {
-            static_assert(!LevelProperties::is_full);
-            static_assert(LevelProperties::is_branchless);
-            static_assert(!LevelProperties::is_compact);
+            static_assert(!_LevelProperties::is_full);
+            static_assert(_LevelProperties::is_branchless);
+            static_assert(!_LevelProperties::is_compact);
             using OffsetContainer = typename ContainerTraits::template Vec<PK>;
 
         public:
@@ -46,14 +46,15 @@ namespace xsparse
                                                  IK,
                                                  PK,
                                                  ContainerTraits,
-                                                 LevelProperties>;
+                                                 _LevelProperties>;
             using LevelCapabilities
                 = level_capabilities::coordinate_position_iterate<offset,
                                                                   std::tuple<LowerLevels...>,
                                                                   IK,
                                                                   PK,
                                                                   ContainerTraits,
-                                                                  LevelProperties>;
+                                                                  _LevelProperties>;
+            using LevelProperties = _LevelProperties;
 
         public:
             offset(IK size)
@@ -72,12 +73,6 @@ namespace xsparse
                 : m_size(std::move(size))
                 , m_offset(offset)
             {
-            }
-
-            // Function to access the LevelProperties object
-            constexpr LevelProperties level_property() const
-            {
-                return LevelProperties{};
             }
 
             inline std::pair<PK, PK> pos_bounds(typename BaseTraits::PKM1 pkm1) const noexcept
@@ -107,9 +102,9 @@ namespace xsparse
               class IK,
               class PK,
               class ContainerTraits,
-              class LevelProperties>
+              class _LevelProperties>
     struct util::coordinate_position_trait<
-        levels::offset<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, LevelProperties>>
+        levels::offset<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, _LevelProperties>>
     {
         using Coordinate = IK;
         using Position = PK;

--- a/include/xsparse/levels/offset.hpp
+++ b/include/xsparse/levels/offset.hpp
@@ -54,7 +54,7 @@ namespace xsparse
                                                                   PK,
                                                                   ContainerTraits,
                                                                   LevelProperties>;
-
+            using LevelProperty = LevelProperties;  // Expose LevelProperties as a public attribute
         public:
             offset(IK size)
                 : m_size(std::move(size))

--- a/include/xsparse/levels/offset.hpp
+++ b/include/xsparse/levels/offset.hpp
@@ -75,7 +75,7 @@ namespace xsparse
             }
 
             // Function to access the LevelProperties object
-            constexpr LevelProperties LevelProperty() const
+            constexpr LevelProperties level_property() const
             {
                 return LevelProperties{};
             }

--- a/include/xsparse/levels/range.hpp
+++ b/include/xsparse/levels/range.hpp
@@ -77,7 +77,7 @@ namespace xsparse
             }
 
             // Function to access the LevelProperties object
-            constexpr LevelProperties LevelProperty() const
+            constexpr LevelProperties level_property() const
             {
                 return LevelProperties{};
             }

--- a/include/xsparse/levels/range.hpp
+++ b/include/xsparse/levels/range.hpp
@@ -53,7 +53,7 @@ namespace xsparse
                                                                PK,
                                                                ContainerTraits,
                                                                LevelProperties>;
-
+            using LevelProperty = LevelProperties;  // Expose LevelProperties as a public attribute
         public:
             range(IK size_N, IK size_M)
                 : m_size_N(std::move(size_N))

--- a/include/xsparse/levels/range.hpp
+++ b/include/xsparse/levels/range.hpp
@@ -53,7 +53,7 @@ namespace xsparse
                                                                PK,
                                                                ContainerTraits,
                                                                LevelProperties>;
-            using LevelProperty = LevelProperties;  // Expose LevelProperties as a public attribute
+
         public:
             range(IK size_N, IK size_M)
                 : m_size_N(std::move(size_N))
@@ -74,6 +74,12 @@ namespace xsparse
                 , m_size_M(std::move(size_M))
                 , m_offset(offset)
             {
+            }
+
+            // Function to access the LevelProperties object
+            constexpr LevelProperties LevelProperty() const
+            {
+                return LevelProperties{};
             }
 
             inline std::pair<IK, IK> coord_bounds(typename BaseTraits::I i) const noexcept

--- a/include/xsparse/levels/range.hpp
+++ b/include/xsparse/levels/range.hpp
@@ -18,25 +18,25 @@ namespace xsparse
                   class PK,
                   class ContainerTraits
                   = util::container_traits<std::vector, std::unordered_set, std::unordered_map>,
-                  class LevelProperties = level_properties<false, true, true, false, false>>
+                  class _LevelProperties = level_properties<false, true, true, false, false>>
         class range;
 
         template <class... LowerLevels,
                   class IK,
                   class PK,
                   class ContainerTraits,
-                  class LevelProperties>
-        class range<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, LevelProperties>
+                  class _LevelProperties>
+        class range<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, _LevelProperties>
             : public level_capabilities::coordinate_value_iterate<range,
                                                                   std::tuple<LowerLevels...>,
                                                                   IK,
                                                                   PK,
                                                                   ContainerTraits,
-                                                                  LevelProperties>
+                                                                  _LevelProperties>
         {
-            static_assert(!LevelProperties::is_full);
-            static_assert(!LevelProperties::is_branchless);
-            static_assert(!LevelProperties::is_compact);
+            static_assert(!_LevelProperties::is_full);
+            static_assert(!_LevelProperties::is_branchless);
+            static_assert(!_LevelProperties::is_compact);
             using OffsetContainer = typename ContainerTraits::template Vec<PK>;
 
         public:
@@ -45,14 +45,15 @@ namespace xsparse
                                                  IK,
                                                  PK,
                                                  ContainerTraits,
-                                                 LevelProperties>;
+                                                 _LevelProperties>;
             using LevelCapabilities
                 = level_capabilities::coordinate_value_iterate<range,
                                                                std::tuple<LowerLevels...>,
                                                                IK,
                                                                PK,
                                                                ContainerTraits,
-                                                               LevelProperties>;
+                                                               _LevelProperties>;
+            using LevelProperties = _LevelProperties;
 
         public:
             range(IK size_N, IK size_M)
@@ -74,12 +75,6 @@ namespace xsparse
                 , m_size_M(std::move(size_M))
                 , m_offset(offset)
             {
-            }
-
-            // Function to access the LevelProperties object
-            constexpr LevelProperties level_property() const
-            {
-                return LevelProperties{};
             }
 
             inline std::pair<IK, IK> coord_bounds(typename BaseTraits::I i) const noexcept
@@ -107,9 +102,9 @@ namespace xsparse
               class IK,
               class PK,
               class ContainerTraits,
-              class LevelProperties>
+              class _LevelProperties>
     struct util::coordinate_position_trait<
-        levels::range<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, LevelProperties>>
+        levels::range<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, _LevelProperties>>
     {
         using Coordinate = IK;
         using Position = PK;

--- a/include/xsparse/levels/singleton.hpp
+++ b/include/xsparse/levels/singleton.hpp
@@ -55,7 +55,7 @@ namespace xsparse
                                                                   PK,
                                                                   ContainerTraits,
                                                                   LevelProperties>;
-
+            using LevelProperty = LevelProperties;  // Expose LevelProperties as a public attribute
         public:
             singleton(IK size)
                 : m_size(std::move(size))

--- a/include/xsparse/levels/singleton.hpp
+++ b/include/xsparse/levels/singleton.hpp
@@ -20,25 +20,25 @@ namespace xsparse
                   class PK,
                   class ContainerTraits
                   = util::container_traits<std::vector, std::unordered_set, std::unordered_map>,
-                  class LevelProperties = level_properties<true, true, true, true, true>>
+                  class _LevelProperties = level_properties<true, true, true, true, true>>
         class singleton;
 
         template <class... LowerLevels,
                   class IK,
                   class PK,
                   class ContainerTraits,
-                  class LevelProperties>
-        class singleton<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, LevelProperties>
+                  class _LevelProperties>
+        class singleton<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, _LevelProperties>
             : public level_capabilities::coordinate_position_iterate<singleton,
                                                                      std::tuple<LowerLevels...>,
                                                                      IK,
                                                                      PK,
                                                                      ContainerTraits,
-                                                                     LevelProperties>
+                                                                     _LevelProperties>
 
         {
-            static_assert(LevelProperties::is_branchless);
-            static_assert(LevelProperties::is_compact);
+            static_assert(_LevelProperties::is_branchless);
+            static_assert(_LevelProperties::is_compact);
             using CrdContainer = typename ContainerTraits::template Vec<PK>;
 
         public:
@@ -47,14 +47,15 @@ namespace xsparse
                                                  IK,
                                                  PK,
                                                  ContainerTraits,
-                                                 LevelProperties>;
+                                                 _LevelProperties>;
             using LevelCapabilities
                 = level_capabilities::coordinate_position_iterate<singleton,
                                                                   std::tuple<LowerLevels...>,
                                                                   IK,
                                                                   PK,
                                                                   ContainerTraits,
-                                                                  LevelProperties>;
+                                                                  _LevelProperties>;
+            using LevelProperties = _LevelProperties;
 
         public:
             singleton(IK size)
@@ -73,12 +74,6 @@ namespace xsparse
                 : m_size(std::move(size))
                 , m_crd(crd)
             {
-            }
-
-            // Function to access the LevelProperties object
-            constexpr LevelProperties level_property() const
-            {
-                return LevelProperties{};
             }
 
             inline std::pair<PK, PK> pos_bounds(typename BaseTraits::PKM1 pkm1) const noexcept
@@ -113,9 +108,9 @@ namespace xsparse
               class IK,
               class PK,
               class ContainerTraits,
-              class LevelProperties>
+              class _LevelProperties>
     struct util::coordinate_position_trait<
-        levels::singleton<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, LevelProperties>>
+        levels::singleton<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, _LevelProperties>>
     {
         using Coordinate = IK;
         using Position = PK;

--- a/include/xsparse/levels/singleton.hpp
+++ b/include/xsparse/levels/singleton.hpp
@@ -76,7 +76,7 @@ namespace xsparse
             }
 
             // Function to access the LevelProperties object
-            constexpr LevelProperties LevelProperty() const
+            constexpr LevelProperties level_property() const
             {
                 return LevelProperties{};
             }

--- a/include/xsparse/levels/singleton.hpp
+++ b/include/xsparse/levels/singleton.hpp
@@ -55,7 +55,7 @@ namespace xsparse
                                                                   PK,
                                                                   ContainerTraits,
                                                                   LevelProperties>;
-            using LevelProperty = LevelProperties;  // Expose LevelProperties as a public attribute
+
         public:
             singleton(IK size)
                 : m_size(std::move(size))
@@ -73,6 +73,12 @@ namespace xsparse
                 : m_size(std::move(size))
                 , m_crd(crd)
             {
+            }
+
+            // Function to access the LevelProperties object
+            constexpr LevelProperties LevelProperty() const
+            {
+                return LevelProperties{};
             }
 
             inline std::pair<PK, PK> pos_bounds(typename BaseTraits::PKM1 pkm1) const noexcept

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,7 @@ include(../cmake/tools.cmake)
 
 include(../cmake/CPM.cmake)
 
-CPMAddPackage("gh:onqtam/doctest#2.4.5")
+CPMAddPackage("gh:doctest/doctest#v2.4.11")
 CPMAddPackage("gh:TheLartians/Format.cmake@1.7.0")
 
 if(TEST_INSTALLED_VERSION)

--- a/test/source/compressed_test.cpp
+++ b/test/source/compressed_test.cpp
@@ -32,10 +32,10 @@ TEST_CASE("Compressed-BaseCase")
     }
     CHECK(l == pos.back());
 
-    // Check basic properties of all compressed levels
-    CHECK(s.LevelProperty().is_full);
-    CHECK(s.LevelProperty().is_ordered);
-    CHECK(s.LevelProperty().is_unique);
+    // Check basic strict properties of all compressed levels
+    // CHECK(s.LevelProperty().is_full);
+    // CHECK(s.LevelProperty().is_ordered);
+    // CHECK(s.LevelProperty().is_unique);
     CHECK(!s.LevelProperty().is_branchless);
     CHECK(s.LevelProperty().is_compact);
 }

--- a/test/source/compressed_test.cpp
+++ b/test/source/compressed_test.cpp
@@ -33,11 +33,11 @@ TEST_CASE("Compressed-BaseCase")
     CHECK(l == pos.back());
 
     // Check basic strict properties of all compressed levels
-    // CHECK(s.LevelProperty().is_full);
-    // CHECK(s.LevelProperty().is_ordered);
-    // CHECK(s.LevelProperty().is_unique);
-    CHECK(!s.LevelProperty().is_branchless);
-    CHECK(s.LevelProperty().is_compact);
+    // CHECK(s.level_property().is_full);
+    // CHECK(s.level_property().is_ordered);
+    // CHECK(s.level_property().is_unique);
+    CHECK(!s.level_property().is_branchless);
+    CHECK(s.level_property().is_compact);
 }
 
 TEST_CASE("Compressed-CSR")

--- a/test/source/compressed_test.cpp
+++ b/test/source/compressed_test.cpp
@@ -31,6 +31,13 @@ TEST_CASE("Compressed-BaseCase")
         ++l;
     }
     CHECK(l == pos.back());
+
+    // Check basic properties of all compressed levels
+    CHECK(s.LevelProperty().is_full);
+    CHECK(s.LevelProperty().is_ordered);
+    CHECK(s.LevelProperty().is_unique);
+    CHECK(!s.LevelProperty().is_branchless);
+    CHECK(s.LevelProperty().is_compact);
 }
 
 TEST_CASE("Compressed-CSR")

--- a/test/source/compressed_test.cpp
+++ b/test/source/compressed_test.cpp
@@ -33,11 +33,8 @@ TEST_CASE("Compressed-BaseCase")
     CHECK(l == pos.back());
 
     // Check basic strict properties of all compressed levels
-    // CHECK(s.level_property().is_full);
-    // CHECK(s.level_property().is_ordered);
-    // CHECK(s.level_property().is_unique);
-    CHECK(!s.level_property().is_branchless);
-    CHECK(s.level_property().is_compact);
+    CHECK(!decltype(s)::LevelProperties::is_branchless);
+    CHECK(decltype(s)::LevelProperties::is_compact);
 }
 
 TEST_CASE("Compressed-CSR")

--- a/test/source/dense_test.cpp
+++ b/test/source/dense_test.cpp
@@ -37,7 +37,7 @@ TEST_CASE("Dense-2D")
     xsparse::levels::dense<std::tuple<>,
                            uintptr_t,
                            uintptr_t,
-                           xsparse::level_properties<true, false, false, false, true>>
+                           xsparse::level_properties<true, true, false, false, true>>
         d1{ SIZE1 };
     xsparse::levels::dense<std::tuple<decltype(d1)>, uintptr_t, uintptr_t> d2{ SIZE2 };
 
@@ -70,7 +70,7 @@ TEST_CASE("Dense-2D-Size")
     xsparse::levels::dense<std::tuple<decltype(d1)>,
                            uintptr_t,
                            uintptr_t,
-                           xsparse::level_properties<true, false, true, false, true>>
+                           xsparse::level_properties<true, true, true, false, true>>
         d2{ SIZE2 };
 
     uintptr_t l1 = 0;

--- a/test/source/dense_test.cpp
+++ b/test/source/dense_test.cpp
@@ -23,9 +23,9 @@ TEST_CASE("Dense-BaseCase")
     CHECK(loop == SIZE);
 
     // Check basic strict properties of all dense levels
-    CHECK(d.level_property().is_full);
-    CHECK(!d.level_property().is_branchless);
-    CHECK(d.level_property().is_compact);
+    CHECK(decltype(d)::LevelProperties::is_full);
+    CHECK(!decltype(d)::LevelProperties::is_branchless);
+    CHECK(decltype(d)::LevelProperties::is_compact);
 }
 
 TEST_CASE("Dense-2D")

--- a/test/source/dense_test.cpp
+++ b/test/source/dense_test.cpp
@@ -24,6 +24,10 @@ TEST_CASE("Dense-BaseCase")
 
     // Check basic properties of all dense levels
     CHECK(d.LevelProperty().is_full);
+    CHECK(d.LevelProperty().is_ordered);
+    CHECK(d.LevelProperty().is_unique);
+    CHECK(!d.LevelProperty().is_branchless);
+    CHECK(d.LevelProperty().is_compact);
 }
 
 TEST_CASE("Dense-2D")

--- a/test/source/dense_test.cpp
+++ b/test/source/dense_test.cpp
@@ -21,6 +21,9 @@ TEST_CASE("Dense-BaseCase")
         ++loop;
     }
     CHECK(loop == SIZE);
+
+    // Check basic properties of all dense levels
+    CHECK(d.LevelProperty().is_full);
 }
 
 TEST_CASE("Dense-2D")

--- a/test/source/dense_test.cpp
+++ b/test/source/dense_test.cpp
@@ -22,10 +22,8 @@ TEST_CASE("Dense-BaseCase")
     }
     CHECK(loop == SIZE);
 
-    // Check basic properties of all dense levels
+    // Check basic strict properties of all dense levels
     CHECK(d.LevelProperty().is_full);
-    CHECK(d.LevelProperty().is_ordered);
-    CHECK(d.LevelProperty().is_unique);
     CHECK(!d.LevelProperty().is_branchless);
     CHECK(d.LevelProperty().is_compact);
 }

--- a/test/source/dense_test.cpp
+++ b/test/source/dense_test.cpp
@@ -23,9 +23,9 @@ TEST_CASE("Dense-BaseCase")
     CHECK(loop == SIZE);
 
     // Check basic strict properties of all dense levels
-    CHECK(d.LevelProperty().is_full);
-    CHECK(!d.LevelProperty().is_branchless);
-    CHECK(d.LevelProperty().is_compact);
+    CHECK(d.level_property().is_full);
+    CHECK(!d.level_property().is_branchless);
+    CHECK(d.level_property().is_compact);
 }
 
 TEST_CASE("Dense-2D")

--- a/test/source/hashed_test.cpp
+++ b/test/source/hashed_test.cpp
@@ -36,11 +36,9 @@ TEST_CASE("Hashed-BaseCase")
     CHECK(l2 == crd[0].size());
 
     // Check basic stric properties of all hashed levels
-    // CHECK(!h.level_property().is_full);
-    CHECK(!h.level_property().is_ordered);
-    // CHECK(!h.level_property().is_unique);
-    CHECK(!h.level_property().is_branchless);
-    CHECK(!h.level_property().is_compact);
+    CHECK(!decltype(h)::LevelProperties::is_ordered);
+    CHECK(!decltype(h)::LevelProperties::is_branchless);
+    CHECK(!decltype(h)::LevelProperties::is_compact);
 }
 
 TEST_CASE("Dense-Hashed")

--- a/test/source/hashed_test.cpp
+++ b/test/source/hashed_test.cpp
@@ -36,11 +36,11 @@ TEST_CASE("Hashed-BaseCase")
     CHECK(l2 == crd[0].size());
 
     // Check basic stric properties of all hashed levels
-    // CHECK(!h.LevelProperty().is_full);
-    CHECK(!h.LevelProperty().is_ordered);
-    // CHECK(!h.LevelProperty().is_unique);
-    CHECK(!h.LevelProperty().is_branchless);
-    CHECK(!h.LevelProperty().is_compact);
+    // CHECK(!h.level_property().is_full);
+    CHECK(!h.level_property().is_ordered);
+    // CHECK(!h.level_property().is_unique);
+    CHECK(!h.level_property().is_branchless);
+    CHECK(!h.level_property().is_compact);
 }
 
 TEST_CASE("Dense-Hashed")

--- a/test/source/hashed_test.cpp
+++ b/test/source/hashed_test.cpp
@@ -35,10 +35,10 @@ TEST_CASE("Hashed-BaseCase")
     }
     CHECK(l2 == crd[0].size());
 
-    // Check basic properties of all hashed levels
-    CHECK(!h.LevelProperty().is_full);
+    // Check basic stric properties of all hashed levels
+    // CHECK(!h.LevelProperty().is_full);
     CHECK(!h.LevelProperty().is_ordered);
-    CHECK(!h.LevelProperty().is_unique);
+    // CHECK(!h.LevelProperty().is_unique);
     CHECK(!h.LevelProperty().is_branchless);
     CHECK(!h.LevelProperty().is_compact);
 }

--- a/test/source/hashed_test.cpp
+++ b/test/source/hashed_test.cpp
@@ -10,6 +10,39 @@
 #include <unordered_map>
 #include <set>
 
+TEST_CASE("Hashed-BaseCase")
+{
+    constexpr uintptr_t SIZE0 = 3;
+    constexpr uint8_t ZERO = 0;
+
+    std::unordered_map<uintptr_t, uintptr_t> const umap1{ { 5, 2 }, { 6, 1 }, { 4, 0 } };
+    std::vector<std::unordered_map<uintptr_t, uintptr_t>> const crd{ umap1 };
+
+    xsparse::levels::hashed<
+        std::tuple<>,
+        uintptr_t,
+        uintptr_t,
+        xsparse::util::container_traits<std::vector, std::set, std::unordered_map>,
+        xsparse::level_properties<false, false, false, false, false>>
+        h{ SIZE0, crd };
+
+    // check iterating through a hashed level
+    uintptr_t l2 = 0;
+    for (auto const [i2, p2] : h.iter_helper(ZERO))
+    {
+        CHECK(crd[0].at(i2) == p2);
+        ++l2;
+    }
+    CHECK(l2 == crd[0].size());
+
+    // Check basic properties of all hashed levels
+    CHECK(!h.LevelProperty().is_full);
+    CHECK(!h.LevelProperty().is_ordered);
+    CHECK(!h.LevelProperty().is_unique);
+    CHECK(!h.LevelProperty().is_branchless);
+    CHECK(!h.LevelProperty().is_compact);
+}
+
 TEST_CASE("Dense-Hashed")
 {
     constexpr uintptr_t SIZE0 = 3;

--- a/test/source/range_test.cpp
+++ b/test/source/range_test.cpp
@@ -10,6 +10,7 @@
 
 #include <iostream>
 
+
 TEST_CASE("Range-DIA")
 {
     constexpr uintptr_t SIZE = 4;
@@ -47,4 +48,18 @@ TEST_CASE("Range-DIA")
         ++l1;
     }
     CHECK(l1 == SIZE);
+
+    // Check basic properties of all range levels
+    CHECK(!r.LevelProperty().is_full);
+    CHECK(r.LevelProperty().is_ordered);
+    CHECK(r.LevelProperty().is_unique);
+    CHECK(!r.LevelProperty().is_branchless);
+    CHECK(!r.LevelProperty().is_compact);
+
+    // Check basic properties of all offset levels
+    CHECK(!o.LevelProperty().is_full);
+    CHECK(o.LevelProperty().is_ordered);
+    CHECK(o.LevelProperty().is_unique);
+    CHECK(o.LevelProperty().is_branchless);
+    CHECK(!o.LevelProperty().is_compact);
 }

--- a/test/source/range_test.cpp
+++ b/test/source/range_test.cpp
@@ -50,16 +50,16 @@ TEST_CASE("Range-DIA")
     CHECK(l1 == SIZE);
 
     // Check basic stric properties of all range levels
-    CHECK(!r.LevelProperty().is_full);
-    // CHECK(r.LevelProperty().is_ordered);
-    // CHECK(r.LevelProperty().is_unique);
-    CHECK(!r.LevelProperty().is_branchless);
-    CHECK(!r.LevelProperty().is_compact);
+    CHECK(!r.level_property().is_full);
+    // CHECK(r.level_property().is_ordered);
+    // CHECK(r.level_property().is_unique);
+    CHECK(!r.level_property().is_branchless);
+    CHECK(!r.level_property().is_compact);
 
     // Check basic properties of all offset levels
-    CHECK(!o.LevelProperty().is_full);
-    // CHECK(o.LevelProperty().is_ordered);
-    // CHECK(o.LevelProperty().is_unique);
-    CHECK(o.LevelProperty().is_branchless);
-    CHECK(!o.LevelProperty().is_compact);
+    CHECK(!o.level_property().is_full);
+    // CHECK(o.level_property().is_ordered);
+    // CHECK(o.level_property().is_unique);
+    CHECK(o.level_property().is_branchless);
+    CHECK(!o.level_property().is_compact);
 }

--- a/test/source/range_test.cpp
+++ b/test/source/range_test.cpp
@@ -49,17 +49,17 @@ TEST_CASE("Range-DIA")
     }
     CHECK(l1 == SIZE);
 
-    // Check basic properties of all range levels
+    // Check basic stric properties of all range levels
     CHECK(!r.LevelProperty().is_full);
-    CHECK(r.LevelProperty().is_ordered);
-    CHECK(r.LevelProperty().is_unique);
+    // CHECK(r.LevelProperty().is_ordered);
+    // CHECK(r.LevelProperty().is_unique);
     CHECK(!r.LevelProperty().is_branchless);
     CHECK(!r.LevelProperty().is_compact);
 
     // Check basic properties of all offset levels
     CHECK(!o.LevelProperty().is_full);
-    CHECK(o.LevelProperty().is_ordered);
-    CHECK(o.LevelProperty().is_unique);
+    // CHECK(o.LevelProperty().is_ordered);
+    // CHECK(o.LevelProperty().is_unique);
     CHECK(o.LevelProperty().is_branchless);
     CHECK(!o.LevelProperty().is_compact);
 }

--- a/test/source/range_test.cpp
+++ b/test/source/range_test.cpp
@@ -50,16 +50,12 @@ TEST_CASE("Range-DIA")
     CHECK(l1 == SIZE);
 
     // Check basic stric properties of all range levels
-    CHECK(!r.level_property().is_full);
-    // CHECK(r.level_property().is_ordered);
-    // CHECK(r.level_property().is_unique);
-    CHECK(!r.level_property().is_branchless);
-    CHECK(!r.level_property().is_compact);
+    CHECK(!decltype(r)::LevelProperties::is_full);
+    CHECK(!decltype(r)::LevelProperties::is_branchless);
+    CHECK(!decltype(r)::LevelProperties::is_compact);
 
     // Check basic properties of all offset levels
-    CHECK(!o.level_property().is_full);
-    // CHECK(o.level_property().is_ordered);
-    // CHECK(o.level_property().is_unique);
-    CHECK(o.level_property().is_branchless);
-    CHECK(!o.level_property().is_compact);
+    CHECK(!decltype(o)::LevelProperties::is_full);
+    CHECK(decltype(o)::LevelProperties::is_branchless);
+    CHECK(!decltype(o)::LevelProperties::is_compact);
 }

--- a/test/source/singleton_test.cpp
+++ b/test/source/singleton_test.cpp
@@ -12,6 +12,31 @@
 #include <xsparse/util/container_traits.hpp>
 #include <xsparse/level_properties.hpp>
 
+
+TEST_CASE("Singleton-BaseCase")
+{
+    constexpr uintptr_t SIZE = 20;
+    constexpr uint8_t ZERO = 0;
+    std::vector<uintptr_t> const crd1{ 0, 1, 0, 1, 0, 3, 4 };
+
+    xsparse::levels::singleton<std::tuple<>, uintptr_t, uintptr_t> s{ SIZE, crd1 };
+
+    uintptr_t l2 = 0;
+    for (auto const [i2, p2] : s.iter_helper(std::make_tuple(), ZERO))
+    {
+        CHECK(l2 == p2);
+        CHECK(crd1[l2] == i2);
+        ++l2;
+    }
+
+    // Check basic properties of all singleton levels
+    CHECK(s.LevelProperty().is_full);
+    CHECK(s.LevelProperty().is_ordered);
+    CHECK(s.LevelProperty().is_unique);
+    CHECK(s.LevelProperty().is_branchless);
+    CHECK(s.LevelProperty().is_compact);
+}
+
 TEST_CASE("Singleton-COO")
 {
     constexpr uintptr_t SIZE = 100;

--- a/test/source/singleton_test.cpp
+++ b/test/source/singleton_test.cpp
@@ -30,11 +30,11 @@ TEST_CASE("Singleton-BaseCase")
     }
 
     // Check basic stric properties of all singleton levels
-    // CHECK(s.LevelProperty().is_full);
-    // CHECK(s.LevelProperty().is_ordered);
-    // CHECK(s.LevelProperty().is_unique);
-    CHECK(s.LevelProperty().is_branchless);
-    CHECK(s.LevelProperty().is_compact);
+    // CHECK(s.level_property().is_full);
+    // CHECK(s.level_property().is_ordered);
+    // CHECK(s.level_property().is_unique);
+    CHECK(s.level_property().is_branchless);
+    CHECK(s.level_property().is_compact);
 }
 
 TEST_CASE("Singleton-COO")

--- a/test/source/singleton_test.cpp
+++ b/test/source/singleton_test.cpp
@@ -29,10 +29,10 @@ TEST_CASE("Singleton-BaseCase")
         ++l2;
     }
 
-    // Check basic properties of all singleton levels
-    CHECK(s.LevelProperty().is_full);
-    CHECK(s.LevelProperty().is_ordered);
-    CHECK(s.LevelProperty().is_unique);
+    // Check basic stric properties of all singleton levels
+    // CHECK(s.LevelProperty().is_full);
+    // CHECK(s.LevelProperty().is_ordered);
+    // CHECK(s.LevelProperty().is_unique);
     CHECK(s.LevelProperty().is_branchless);
     CHECK(s.LevelProperty().is_compact);
 }

--- a/test/source/singleton_test.cpp
+++ b/test/source/singleton_test.cpp
@@ -30,11 +30,8 @@ TEST_CASE("Singleton-BaseCase")
     }
 
     // Check basic stric properties of all singleton levels
-    // CHECK(s.level_property().is_full);
-    // CHECK(s.level_property().is_ordered);
-    // CHECK(s.level_property().is_unique);
-    CHECK(s.level_property().is_branchless);
-    CHECK(s.level_property().is_compact);
+    CHECK(decltype(s)::LevelProperties::is_branchless);
+    CHECK(decltype(s)::LevelProperties::is_compact);
 }
 
 TEST_CASE("Singleton-COO")


### PR DESCRIPTION
Towards: #19 

Adds LevelProperty() constexpr function to allow each class access to the levelproperties during compile time, without explicitly writing the class type. 