### PR TITLE
[ENH] Level capabilities refactor for hashed level

### DIFF
--- a/include/xsparse/level_capabilities/coordinate_iterate.hpp
+++ b/include/xsparse/level_capabilities/coordinate_iterate.hpp
@@ -4,6 +4,7 @@
 #include <iterator>
 #include <tuple>
 #include <optional>
+#include <unordered_map>
 #include <type_traits>
 #include <utility>
 
@@ -11,6 +12,7 @@
 
 #include <xsparse/util/template_utils.hpp>
 #include <xsparse/util/base_traits.hpp>
+#include <xsparse/util/container_traits.hpp>
 
 
 namespace xsparse::level_capabilities
@@ -267,6 +269,99 @@ namespace xsparse::level_capabilities
         iteration_helper iter_helper(typename BaseTraits::I i, typename BaseTraits::PKM1 pkm1)
         {
             return iteration_helper{ *static_cast<typename BaseTraits::Level*>(this), i, pkm1 };
+        }
+    };
+
+    template <template <class...> class T,
+              class IK,
+              class PK,
+              class ContainerTraits,
+              class... LowerLevels>
+    class coordinate_pos_locate_iterate
+    {
+        using BaseTraits = util::base_traits<T, IK, PK, LowerLevels...>;
+
+    public:
+        class iteration_helper
+        {
+            static_assert(std::is_nothrow_invocable_r_v<std::optional<typename BaseTraits::PK>,
+                                                        decltype(&BaseTraits::Level::locate),
+                                                        typename BaseTraits::Level&,
+                                                        typename BaseTraits::PKM1,
+                                                        typename BaseTraits::IK>);
+
+        private:
+            typename ContainerTraits::template Map<typename BaseTraits::IK, typename BaseTraits::PK>
+                m_map;
+
+        public:
+            class iterator;
+            using key_type = typename BaseTraits::IK;
+            using value_type = typename std::pair<typename BaseTraits::IK, typename BaseTraits::PK>;
+            using difference_type = typename std::make_signed_t<typename BaseTraits::PK>;
+            using pointer = typename std::pair<typename BaseTraits::IK, typename BaseTraits::PK>*;
+            using reference = std::pair<typename BaseTraits::IK, typename BaseTraits::PK>;
+            using iterator_type = iterator;
+
+            class iterator : public xtl::xrandom_access_iterator_base2<iteration_helper>
+            {
+            private:
+                using wrapped_iterator_type =
+                    typename ContainerTraits::template Map<typename BaseTraits::IK,
+                                                           typename BaseTraits::PK>::const_iterator;
+                wrapped_iterator_type wrapped_it;
+
+            public:
+                explicit inline iterator(wrapped_iterator_type wrapped) noexcept
+                    : wrapped_it(wrapped)
+                {
+                }
+
+                inline std::tuple<typename BaseTraits::IK, typename BaseTraits::PK> operator*()
+                    const noexcept
+                {
+                    return { wrapped_it->first, wrapped_it->second };
+                }
+
+                inline bool operator==(const iterator& other) const noexcept
+                {
+                    return wrapped_it == other.wrapped_it;
+                }
+
+                inline iterator& operator++() noexcept
+                {
+                    ++wrapped_it;
+                    return *this;
+                }
+
+                inline iterator& operator--() noexcept
+                {
+                    --wrapped_it;
+                    return *this;
+                }
+            };
+
+            explicit inline iteration_helper(
+                typename ContainerTraits::template Map<typename BaseTraits::IK,
+                                                       typename BaseTraits::PK>& map) noexcept
+                : m_map(map)
+            {
+            }
+
+            inline iterator_type begin() const noexcept
+            {
+                return iterator_type{ m_map.begin() };
+            }
+
+            inline iterator_type end() const noexcept
+            {
+                return iterator_type{ m_map.end() };
+            }
+        };
+
+        iteration_helper iter_helper(typename BaseTraits::PKM1 pkm1)
+        {
+            return iteration_helper{ this->m_crd[pkm1] };
         }
     };
 }

--- a/include/xsparse/levels/hashed.hpp
+++ b/include/xsparse/levels/hashed.hpp
@@ -8,10 +8,9 @@
 #include <unordered_set>
 #include <unordered_map>
 
-#include <xsparse/util/base_traits.hpp>
+#include <xsparse/level_capabilities/coordinate_iterate.hpp>
 #include <xsparse/util/container_traits.hpp>
 #include <xsparse/level_properties.hpp>
-#include <xtl/xiterator_base.hpp>
 
 namespace xsparse
 {
@@ -45,94 +44,16 @@ namespace xsparse
                                                  PK,
                                                  ContainerTraits,
                                                  _LevelProperties>;
-            using 
+            using LevelCapabilities
+                = level_capabilities::coordinate_pos_locate_iterate<hashed,
+                                                                    std::tuple<LowerLevels...>,
+                                                                    IK,
+                                                                    PK,
+                                                                    ContainerTraits,
+                                                                    _LevelProperties>;
             using LevelProperties = _LevelProperties;
 
         public:
-            class iteration_helper
-            {
-                static_assert(std::is_nothrow_invocable_r_v<std::optional<typename BaseTraits::PK>,
-                                                            decltype(&BaseTraits::Level::locate),
-                                                            typename BaseTraits::Level&,
-                                                            typename BaseTraits::PKM1,
-                                                            typename BaseTraits::IK>);
-
-            private:
-                typename ContainerTraits::template Map<typename BaseTraits::IK,
-                                                       typename BaseTraits::PK>
-                    m_map;
-
-            public:
-                class iterator;
-                using value_type =
-                    typename std::pair<typename BaseTraits::IK, typename BaseTraits::PK>;
-                using difference_type = typename std::make_signed_t<typename BaseTraits::PK>;
-                using pointer =
-                    typename std::pair<typename BaseTraits::IK, typename BaseTraits::PK>*;
-                using reference = std::pair<typename BaseTraits::IK, typename BaseTraits::PK>;
-                using iterator_type = iterator;
-
-                class iterator : public xtl::xbidirectional_iterator_base2<iteration_helper>
-                {
-                private:
-                    using wrapped_iterator_type = typename ContainerTraits::template Map<
-                        typename BaseTraits::IK,
-                        typename BaseTraits::PK>::const_iterator;
-                    wrapped_iterator_type wrapped_it;
-
-                public:
-                    explicit inline iterator(wrapped_iterator_type wrapped) noexcept
-                        : wrapped_it(wrapped)
-                    {
-                    }
-
-                    inline std::tuple<typename BaseTraits::IK, typename BaseTraits::PK> operator*()
-                        const noexcept
-                    {
-                        return { wrapped_it->first, wrapped_it->second };
-                    }
-
-                    inline bool operator==(const iterator& other) const noexcept
-                    {
-                        return wrapped_it == other.wrapped_it;
-                    }
-
-                    inline iterator& operator++() noexcept
-                    {
-                        ++wrapped_it;
-                        return *this;
-                    }
-
-                    inline iterator& operator--() noexcept
-                    {
-                        --wrapped_it;
-                        return *this;
-                    }
-                };
-
-                explicit inline iteration_helper(
-                    typename ContainerTraits::template Map<typename BaseTraits::IK,
-                                                           typename BaseTraits::PK>& map) noexcept
-                    : m_map(map)
-                {
-                }
-
-                inline iterator_type begin() const noexcept
-                {
-                    return iterator_type{ m_map.begin() };
-                }
-
-                inline iterator_type end() const noexcept
-                {
-                    return iterator_type{ m_map.end() };
-                }
-            };
-
-            iteration_helper iter_helper(typename BaseTraits::PKM1 pkm1)
-            {
-                return iteration_helper{ this->m_crd[pkm1] };
-            }
-
             hashed(IK size)
                 : m_size(std::move(size))
                 , m_crd()

--- a/include/xsparse/levels/hashed.hpp
+++ b/include/xsparse/levels/hashed.hpp
@@ -30,6 +30,12 @@ namespace xsparse
                   class ContainerTraits,
                   class _LevelProperties>
         class hashed<std::tuple<LowerLevels...>, IK, PK, ContainerTraits, _LevelProperties>
+            : public level_capabilities::coordinate_pos_locate_iterate<hashed,
+                                                                       std::tuple<LowerLevels...>,
+                                                                       IK,
+                                                                       PK,
+                                                                       ContainerTraits,
+                                                                       _LevelProperties>
         {
             static_assert(!_LevelProperties::is_ordered);
             static_assert(!_LevelProperties::is_branchless);

--- a/include/xsparse/levels/hashed.hpp
+++ b/include/xsparse/levels/hashed.hpp
@@ -45,6 +45,7 @@ namespace xsparse
                                                  PK,
                                                  ContainerTraits,
                                                  _LevelProperties>;
+            using 
             using LevelProperties = _LevelProperties;
 
         public:


### PR DESCRIPTION
Towards: #19 

The hashed.hpp file implemented its own `iteration_helper` class, whereas the `Coiterate` API relies on each level having iteration helper within a `level_capabilities` namespace. 

This PR attempts to refactor the `iteration_helper` part of hashed into the `coordinate_iterate.hpp` file.

### Bottlenecks

For some reason I get compilation errors that `iter_helper` is not found, even tho it is now part of the hashed level through the level_capabilities namespace:

```
/Users/adam2392/Documents/xsparse/test/source/hashed_test.cpp:31:34: error: no member named 'iter_helper' in 'xsparse::levels::hashed<std::tuple<>, unsigned long, unsigned long, xsparse::util::container_traits<std::vector, std::set, std::unordered_map>, xsparse::level_properties<false, false, false, false, false>>'
    for (auto const [i2, p2] : h.iter_helper(ZERO))
                               ~ ^
```
and also

```
/Users/adam2392/Documents/xsparse/include/xsparse/util/base_traits.hpp:34:9: error: static_assert failed due to requirement 'std::is_convertible_v<xsparse::util::container_traits<std::vector, std::set, std::unordered_map>, unsigned long>' "`PK` must be convertible to uintptr_t."
        static_assert(std::is_convertible_v<PK, uintptr_t>,
        ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Notes from July 11th, 2023:
- Change `Levels::LevelCapabilities::iteration_helper` to `Levels::iteration_helper` to remove requirement of namespace LevelCapabilities in Coiteration
- Add maybe-unused parameter I to the initialization of hashed level iteration_helper
- 