### PR TITLE
Adding required member functions of abstract container traits

### DIFF
--- a/include/xsparse/util/container_traits.hpp
+++ b/include/xsparse/util/container_traits.hpp
@@ -40,9 +40,9 @@ namespace xsparse::util
                            decltype(std::declval<Vec<double>>().at(std::declval<std::size_t>()))>,
             "Vec must have `operator[]` method with the correct signature.");
 
-        static_assert(std::is_same_v<decltype(std::declval<Map<int, std::size_t>>().find(
-                                         std::declval<std::size_t>())),
-                                     typename Map<int, std::size_t>::iterator>,
+        static_assert(std::is_same_v<
+                          decltype(std::declval<Map<int, std::size_t>>().find(std::declval<int>())),
+                          typename Map<int, std::size_t>::iterator>,
                       "Map must have `find` method with the correct signature.");
 
         static_assert(std::is_same_v<decltype(std::declval<Set<std::size_t>>().contains(

--- a/include/xsparse/util/container_traits.hpp
+++ b/include/xsparse/util/container_traits.hpp
@@ -7,84 +7,6 @@
 
 namespace xsparse::util
 {
-    // Helper type trait to check the signature of push_back method
-    template <class Container, class Elem>
-    struct has_push_back
-    {
-        template <typename C, typename E>
-        static auto test(int)
-            -> decltype(std::declval<C>().push_back(std::declval<E>()), std::true_type());
-
-        template <typename, typename>
-        static auto test(...) -> std::false_type;
-
-        static constexpr bool value = decltype(test<Container, Elem>(0))::value;
-    };
-
-    // Helper type trait to check the signature of resize method
-    template <class Container, class Size>
-    struct has_resize
-    {
-        template <typename C, typename S>
-        static auto test(int)
-            -> decltype(std::declval<C>().resize(std::declval<S>()), std::true_type());
-
-        template <typename, typename>
-        static auto test(...) -> std::false_type;
-
-        static constexpr bool value = decltype(test<Container, Size>(0))::value;
-    };
-
-    // Helper type trait to check the signature of operator[] method
-    template <class Container, class Index>
-    struct has_operator_index
-    {
-        template <typename C, typename I>
-        static auto test(int) -> decltype(std::declval<C>()[std::declval<I>()], std::true_type());
-
-        template <typename, typename>
-        static auto test(...) -> std::false_type;
-
-        static constexpr bool value = decltype(test<Container, Index>(0))::value;
-    };
-
-    // Helper type trait to check if both push_back and resize are valid for the given container
-    template <class Container, class Elem, class Index>
-    struct has_valid_vec_methods
-    {
-        static constexpr bool value = has_push_back<Container, Elem>::value
-                                      && has_resize<Container, typename Container::size_type>::value
-                                      && has_operator_index<Container, Index>::value;
-    };
-
-    // Helper type trait to check the signature of find method
-    template <class Container, class Key>
-    struct has_find
-    {
-        template <typename C, typename K>
-        static auto test(int)
-            -> decltype(std::declval<C>().find(std::declval<K>()), std::true_type());
-
-        template <typename, typename>
-        static auto test(...) -> std::false_type;
-
-        static constexpr bool value = decltype(test<Container, Key>(0))::value;
-    };
-
-    // Helper type trait to check the signature of find method
-    template <class Container, class Key>
-    struct has_contains
-    {
-        template <typename C, typename K>
-        static auto test(int)
-            -> decltype(std::declval<C>().contains(std::declval<K>()), std::true_type());
-
-        template <typename, typename>
-        static auto test(...) -> std::false_type;
-
-        static constexpr bool value = decltype(test<Container, Key>(0))::value;
-    };
-
     template <template <class...> class TVec,
               template <class...>
               class TSet,
@@ -103,36 +25,30 @@ namespace xsparse::util
 
         // Check that the container traits have the properly defined methods and method signatures
         // uses sample type inputs to check the signatures
-        // static_assert(decltype(std::declval<Vec>().contains(std::declval<double>())), std::true_type());
-        // static_assert(std::is_same_v<decltype(std::declval<Vec>().contains(std::declval<double>())), std::true_type>);
-
-        // static_assert(
-        //     has_valid_vec_methods<Vec<double>, double, std::size_t>::value,
-        //     "Vec must have `push_back`, `resize` and `operator[]` methods with the correct signatures.");
-        // static_assert(has_find<Map<int, std::size_t>, std::size_t>::value,
-        //               "Map must have find and resize methods with the correct signatures.");
-        // static_assert(has_contains<Set<std::size_t>, std::size_t>::value,
-        //               "Set must have contain methods with the correct signatures.");
-
         static_assert(
-            std::is_same_v<decltype(std::declval<Vec<double>>().push_back(std::declval<double>())), void>,
+            std::is_same_v<decltype(std::declval<Vec<double>>().push_back(std::declval<double>())),
+                           void>,
             "Vec must have `push_back` method with the correct signature.");
 
-        static_assert(
-            std::is_same_v<decltype(std::declval<Vec<double>>().resize(std::declval<typename Vec<double>::size_type>())), void>,
-            "Vec must have `resize` method with the correct signature.");
+        static_assert(std::is_same_v<decltype(std::declval<Vec<double>>().resize(
+                                         std::declval<typename Vec<double>::size_type>())),
+                                     void>,
+                      "Vec must have `resize` method with the correct signature.");
 
         static_assert(
-            std::is_same_v<decltype(std::declval<Vec<double>>()[std::declval<std::size_t>()]), decltype(std::declval<Vec<double>>().at(std::declval<std::size_t>()))>,
+            std::is_same_v<decltype(std::declval<Vec<double>>()[std::declval<std::size_t>()]),
+                           decltype(std::declval<Vec<double>>().at(std::declval<std::size_t>()))>,
             "Vec must have `operator[]` method with the correct signature.");
 
-        static_assert(
-            std::is_same_v<decltype(std::declval<Map<int, std::size_t>>().find(std::declval<std::size_t>())), typename Map<int, std::size_t>::iterator>,
-            "Map must have `find` method with the correct signature.");
+        static_assert(std::is_same_v<decltype(std::declval<Map<int, std::size_t>>().find(
+                                         std::declval<std::size_t>())),
+                                     typename Map<int, std::size_t>::iterator>,
+                      "Map must have `find` method with the correct signature.");
 
-        static_assert(
-            std::is_same_v<decltype(std::declval<Set<std::size_t>>().contains(std::declval<std::size_t>())), bool>,
-            "Set must have `contains` method with the correct signature.");
+        static_assert(std::is_same_v<decltype(std::declval<Set<std::size_t>>().contains(
+                                         std::declval<std::size_t>())),
+                                     bool>,
+                      "Set must have `contains` method with the correct signature.");
     };
 }
 

--- a/include/xsparse/util/container_traits.hpp
+++ b/include/xsparse/util/container_traits.hpp
@@ -50,7 +50,7 @@ namespace xsparse::util
 
     // Helper type trait to check if both push_back and resize are valid for the given container
     template <class Container, class Elem, class Index>
-    struct has_valid_methods
+    struct has_valid_vec_methods
     {
         static constexpr bool value = has_push_back<Container, Elem>::value
                                       && has_resize<Container, typename Container::size_type>::value
@@ -64,6 +64,20 @@ namespace xsparse::util
         template <typename C, typename K>
         static auto test(int)
             -> decltype(std::declval<C>().find(std::declval<K>()), std::true_type());
+
+        template <typename, typename>
+        static auto test(...) -> std::false_type;
+
+        static constexpr bool value = decltype(test<Container, Key>(0))::value;
+    };
+
+    // Helper type trait to check the signature of find method
+    template <class Container, class Key>
+    struct has_contains
+    {
+        template <typename C, typename K>
+        static auto test(int)
+            -> decltype(std::declval<C>().contains(std::declval<K>()), std::true_type());
 
         template <typename, typename>
         static auto test(...) -> std::false_type;
@@ -90,10 +104,12 @@ namespace xsparse::util
         // Check that the container traits have the properly defined methods and method signatures
         // uses sample type inputs to check the signatures
         static_assert(
-            has_valid_methods<Vec<double>, double, std::size_t>::value,
+            has_valid_vec_methods<Vec<double>, double, std::size_t>::value,
             "Vec must have `push_back`, `resize` and `operator[]` methods with the correct signatures.");
         static_assert(has_find<Map<int, std::size_t>, std::size_t>::value,
                       "Map must have find and resize methods with the correct signatures.");
+        static_assert(has_contains<Set<std::size_t>, std::size_t>::value,
+                      "Set must have contain methods with the correct signatures.");
     };
 }
 

--- a/include/xsparse/util/container_traits.hpp
+++ b/include/xsparse/util/container_traits.hpp
@@ -103,13 +103,36 @@ namespace xsparse::util
 
         // Check that the container traits have the properly defined methods and method signatures
         // uses sample type inputs to check the signatures
+        // static_assert(decltype(std::declval<Vec>().contains(std::declval<double>())), std::true_type());
+        // static_assert(std::is_same_v<decltype(std::declval<Vec>().contains(std::declval<double>())), std::true_type>);
+
+        // static_assert(
+        //     has_valid_vec_methods<Vec<double>, double, std::size_t>::value,
+        //     "Vec must have `push_back`, `resize` and `operator[]` methods with the correct signatures.");
+        // static_assert(has_find<Map<int, std::size_t>, std::size_t>::value,
+        //               "Map must have find and resize methods with the correct signatures.");
+        // static_assert(has_contains<Set<std::size_t>, std::size_t>::value,
+        //               "Set must have contain methods with the correct signatures.");
+
         static_assert(
-            has_valid_vec_methods<Vec<double>, double, std::size_t>::value,
-            "Vec must have `push_back`, `resize` and `operator[]` methods with the correct signatures.");
-        static_assert(has_find<Map<int, std::size_t>, std::size_t>::value,
-                      "Map must have find and resize methods with the correct signatures.");
-        static_assert(has_contains<Set<std::size_t>, std::size_t>::value,
-                      "Set must have contain methods with the correct signatures.");
+            std::is_same_v<decltype(std::declval<Vec<double>>().push_back(std::declval<double>())), void>,
+            "Vec must have `push_back` method with the correct signature.");
+
+        static_assert(
+            std::is_same_v<decltype(std::declval<Vec<double>>().resize(std::declval<typename Vec<double>::size_type>())), void>,
+            "Vec must have `resize` method with the correct signature.");
+
+        static_assert(
+            std::is_same_v<decltype(std::declval<Vec<double>>()[std::declval<std::size_t>()]), decltype(std::declval<Vec<double>>().at(std::declval<std::size_t>()))>,
+            "Vec must have `operator[]` method with the correct signature.");
+
+        static_assert(
+            std::is_same_v<decltype(std::declval<Map<int, std::size_t>>().find(std::declval<std::size_t>())), typename Map<int, std::size_t>::iterator>,
+            "Map must have `find` method with the correct signature.");
+
+        static_assert(
+            std::is_same_v<decltype(std::declval<Set<std::size_t>>().contains(std::declval<std::size_t>())), bool>,
+            "Set must have `contains` method with the correct signature.");
     };
 }
 

--- a/include/xsparse/util/container_traits.hpp
+++ b/include/xsparse/util/container_traits.hpp
@@ -7,6 +7,70 @@
 
 namespace xsparse::util
 {
+    // Helper type trait to check the signature of push_back method
+    template <class Container, class Elem>
+    struct has_push_back
+    {
+        template <typename C, typename E>
+        static auto test(int)
+            -> decltype(std::declval<C>().push_back(std::declval<E>()), std::true_type());
+
+        template <typename, typename>
+        static auto test(...) -> std::false_type;
+
+        static constexpr bool value = decltype(test<Container, Elem>(0))::value;
+    };
+
+    // Helper type trait to check the signature of resize method
+    template <class Container, class Size>
+    struct has_resize
+    {
+        template <typename C, typename S>
+        static auto test(int)
+            -> decltype(std::declval<C>().resize(std::declval<S>()), std::true_type());
+
+        template <typename, typename>
+        static auto test(...) -> std::false_type;
+
+        static constexpr bool value = decltype(test<Container, Size>(0))::value;
+    };
+
+    // Helper type trait to check the signature of operator[] method
+    template <class Container, class Index>
+    struct has_operator_index
+    {
+        template <typename C, typename I>
+        static auto test(int) -> decltype(std::declval<C>()[std::declval<I>()], std::true_type());
+
+        template <typename, typename>
+        static auto test(...) -> std::false_type;
+
+        static constexpr bool value = decltype(test<Container, Index>(0))::value;
+    };
+
+    // Helper type trait to check if both push_back and resize are valid for the given container
+    template <class Container, class Elem, class Index>
+    struct has_valid_methods
+    {
+        static constexpr bool value = has_push_back<Container, Elem>::value
+                                      && has_resize<Container, typename Container::size_type>::value
+                                      && has_operator_index<Container, Index>::value;
+    };
+
+    // Helper type trait to check the signature of find method
+    template <class Container, class Key>
+    struct has_find
+    {
+        template <typename C, typename K>
+        static auto test(int)
+            -> decltype(std::declval<C>().find(std::declval<K>()), std::true_type());
+
+        template <typename, typename>
+        static auto test(...) -> std::false_type;
+
+        static constexpr bool value = decltype(test<Container, Key>(0))::value;
+    };
+
     template <template <class...> class TVec,
               template <class...>
               class TSet,
@@ -23,17 +87,13 @@ namespace xsparse::util
         template <class Key, class Val>
         using Map = TMap<Key, Val>;
 
-        // Required member functions that must be implemented by the container traits.
-        static void resize(std::size_t new_size);
-
-        template <class Elem>
-        static void push_back(const Elem& value);
-
-        template <class Key, class Val>
-        static Val find(const Key& key);
-
-        // Overloaded operator[] for accessing elements by index.
-        inline auto operator[](std::size_t index);
+        // Check that the container traits have the properly defined methods and method signatures
+        // uses sample type inputs to check the signatures
+        static_assert(
+            has_valid_methods<Vec<std::double_t>, std::double_t, std::size_t>::value,
+            "Vec must have `push_back`, `resize` and `operator[]` methods with the correct signatures.");
+        static_assert(has_find<Map<int, std::size_t>, std::size_t>::value,
+                      "Map must have find and resize methods with the correct signatures.");
     };
 }
 

--- a/include/xsparse/util/container_traits.hpp
+++ b/include/xsparse/util/container_traits.hpp
@@ -90,7 +90,7 @@ namespace xsparse::util
         // Check that the container traits have the properly defined methods and method signatures
         // uses sample type inputs to check the signatures
         static_assert(
-            has_valid_methods<Vec<std::double_t>, std::double_t, std::size_t>::value,
+            has_valid_methods<Vec<double>, double, std::size_t>::value,
             "Vec must have `push_back`, `resize` and `operator[]` methods with the correct signatures.");
         static_assert(has_find<Map<int, std::size_t>, std::size_t>::value,
                       "Map must have find and resize methods with the correct signatures.");

--- a/include/xsparse/util/container_traits.hpp
+++ b/include/xsparse/util/container_traits.hpp
@@ -22,6 +22,18 @@ namespace xsparse::util
 
         template <class Key, class Val>
         using Map = TMap<Key, Val>;
+
+        // Required member functions that must be implemented by the container traits.
+        static void resize(std::size_t new_size);
+
+        template <class Elem>
+        static void push_back(const Elem& value);
+
+        template <class Key, class Val>
+        static Val find(const Key& key);
+
+        // Overloaded operator[] for accessing elements by index.
+        inline auto operator[](std::size_t index);
     };
 }
 


### PR DESCRIPTION
Towards: #27 

cc: @bharath2438 is this something along the lines of what you were thinking to add required API for a user defining their own container traits?